### PR TITLE
Fix reversed coordinates in generated GeoJSON

### DIFF
--- a/util/geojson.ts
+++ b/util/geojson.ts
@@ -15,11 +15,11 @@ export function bboxToPolygon(
       type: 'Polygon',
       coordinates: [
         [
-          [minLat, minLon],
-          [minLat, maxLon],
-          [maxLat, maxLon],
-          [maxLat, minLon],
-          [minLat, minLon],
+          [minLon, minLat],
+          [minLon, maxLat],
+          [maxLon, maxLat],
+          [maxLon, minLat],
+          [minLon, minLat]
         ]
       ]
     }


### PR DESCRIPTION
In some cases, Workspaces reverses the order of latitude and longitude in the `dataset_area` metadata property when exporting a workspace to the TDEI. GeoJSON defines point coordinates as `[lon, lat]`. This fixes the order.