### PR TITLE
Fill in content behind navbar "help" link

### DIFF
--- a/components/AppNavbar.vue
+++ b/components/AppNavbar.vue
@@ -22,7 +22,7 @@
             <nuxt-link class="nav-link" to="/workspace/create">Create Workspace</nuxt-link>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#">Help</a>
+            <nuxt-link class="nav-link" to="/help">Help</nuxt-link>
           </li>
         </ul>
 

--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -2,6 +2,7 @@ import { tdeiClient } from '~/services/index'
 
 const ALLOW_ANONYMOUS = new Set([
   '/',
+  '/help',
   '/signin'
 ]);
 

--- a/pages/help.vue
+++ b/pages/help.vue
@@ -1,0 +1,83 @@
+<template>
+  <app-page>
+    <div class="text-center mt-5">
+      <app-icon
+        variant="help"
+        size="48"
+        no-margin
+      />
+    </div>
+    <h1 class="mb-5 text-center">
+      Help &amp; Support
+    </h1>
+
+    <b-row>
+      <b-col
+        md="6"
+        xl="5"
+        xxl="4"
+        class="mb-3"
+        offset-xl="1"
+        offset-xxl="2"
+      >
+        <b-card>
+          <template #header>
+            <h2 class="h5 mb-0">
+              <app-icon
+                variant="menu_book"
+                size="24"
+              />
+              Documentation
+            </h2>
+          </template>
+
+          <p>
+            Step-by-step guides for creating and managing workspaces, editing,
+            exporting data, and more.
+          </p>
+
+          <b-button
+            href="https://taskarcenteratuw.github.io/tcat-wiki/workspaces/"
+            target="_blank"
+            variant="primary"
+          >
+            Open Workspaces Guides
+            <app-icon
+              variant="open_in_new"
+              size="18"
+              class="ms-1"
+            />
+          </b-button>
+        </b-card>
+      </b-col>
+
+      <b-col
+        md="6"
+        xl="5"
+        xxl="4"
+        class="mb-3"
+      >
+        <b-card>
+          <template #header>
+            <h2 class="h5 mb-0">
+              <app-icon
+                variant="mail"
+                size="24"
+              />
+              Contact Support
+            </h2>
+          </template>
+
+          <p>Have a question or need help? Reach out to the TDEI helpdesk.</p>
+
+          <b-button
+            href="mailto:helpdesk@tdei.us"
+            variant="outline-primary"
+          >
+            helpdesk@tdei.us
+          </b-button>
+        </b-card>
+      </b-col>
+    </b-row>
+  </app-page>
+</template>


### PR DESCRIPTION
This adds a landing page for the "help" link that links to the TCAT Wiki and offers a helpdesk contact address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Help & Support page featuring documentation resources and direct contact options for the support team.
  * Updated the Help navigation link to properly route to the new help page.
  * Help page is now accessible to all users without requiring authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->