### PR TITLE
Add initial permissions system

### DIFF
--- a/components/ProjectGroupPicker.vue
+++ b/components/ProjectGroupPicker.vue
@@ -45,11 +45,11 @@
           </li>
           <li
             v-for="(pg, index) in projectGroups"
-            :key="pg.id"
+            :key="pg.tdei_project_group_id"
             :id="'pg-item-' + index"
             class="list-group-item list-group-item-action cursor-pointer"
-            :class="{ highlighted: activeIndex === index, 'fw-bold': model === pg.id }"
-            @click="selectGroup(pg.id)"
+            :class="{ highlighted: activeIndex === index, 'fw-bold': model === pg.tdei_project_group_id }"
+            @click="selectGroup(pg.tdei_project_group_id)"
             @mouseenter="activeIndex = index"
           >
             {{ pg.name }}
@@ -86,21 +86,24 @@ function persistCachedName(id: string, name: string) {
 <script setup lang="ts">
 import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { tdeiUserClient } from '~/services/index'
+import type { TdeiProjectGroupItem } from '~/types/tdei'
 
-const props = withDefaults(defineProps<{ disabled?: boolean }>(), {
+const props = withDefaults(defineProps<{ disabled?: boolean; options?: TdeiProjectGroupItem[] }>(), {
   disabled: false,
 })
 
 const model = defineModel({ required: true })
 const searchText = ref('')
 const isOpen = ref(false)
-const projectGroups = ref<{ id: string; name: string }[]>([])
+const fetchedGroups = ref<TdeiProjectGroupItem[]>([])
 const selectedGroupName = ref('')
 const loading = ref(false)
 const totalCount = ref<number | undefined>(undefined)
 const pickerRef = ref<HTMLElement | null>(null)
 const listRef = ref<HTMLElement | null>(null)
 const activeIndex = ref(-1)
+
+const projectGroups = computed(() => props.options ?? fetchedGroups.value)
 
 let pageNo = 1
 const hasMore = ref(true)
@@ -109,6 +112,8 @@ const pageSize = 10
 let hasUnfilteredResults = false
 
 const loadGroups = async (reset = false) => {
+  if (props.options) return
+
   if (loading.value) {
     pendingReset = pendingReset || reset
     return
@@ -117,7 +122,7 @@ const loadGroups = async (reset = false) => {
   if (reset) {
     pageNo = 1
     hasMore.value = true
-    projectGroups.value = []
+    fetchedGroups.value = []
     activeIndex.value = -1
     totalCount.value = undefined
   }
@@ -136,9 +141,9 @@ const loadGroups = async (reset = false) => {
 
     const { items: newGroups, total } = await tdeiUserClient.getMyProjectGroups(pageNo, query, pageSize)
     if (total !== undefined) totalCount.value = total
-    projectGroups.value.push(...newGroups)
-    const selected = newGroups.find(g => g.id === model.value)
-    if (selected) persistCachedName(selected.id, selected.name)
+    fetchedGroups.value.push(...newGroups)
+    const selected = newGroups.find(g => g.tdei_project_group_id === model.value)
+    if (selected) persistCachedName(selected.tdei_project_group_id, selected.name)
 
     if (newGroups.length < pageSize) {
       hasMore.value = false
@@ -178,7 +183,7 @@ const onInput = () => {
 }
 
 watch(model, (newId) => {
-  const pg = projectGroups.value.find(p => p.id === newId)
+  const pg = projectGroups.value.find(p => p.tdei_project_group_id === newId)
   if (pg && !isOpen.value) {
     searchText.value = pg.name
     selectedGroupName.value = pg.name
@@ -195,11 +200,11 @@ const onScroll = (e: Event) => {
 const selectGroup = (id: string) => {
   model.value = id
   isOpen.value = false
-  const pg = projectGroups.value.find(p => p.id === id)
+  const pg = projectGroups.value.find(p => p.tdei_project_group_id === id)
   if (pg) {
     searchText.value = pg.name
     selectedGroupName.value = pg.name
-    persistCachedName(pg.id, pg.name)
+    persistCachedName(pg.tdei_project_group_id, pg.name)
   }
 }
 
@@ -257,7 +262,7 @@ const onKeydown = (e: KeyboardEvent) => {
     e.preventDefault()
     if (activeIndex.value >= 0 && activeIndex.value < projectGroups.value.length) {
       const pg = projectGroups.value[activeIndex.value]
-      if (pg) selectGroup(pg.id)
+      if (pg) selectGroup(pg.tdei_project_group_id)
     }
   } else if (e.key === 'Escape') {
     e.preventDefault()
@@ -273,7 +278,7 @@ const applyCachedName = () => {
 
 const closeDropdown = () => {
   isOpen.value = false
-  const pg = projectGroups.value.find(p => p.id === model.value)
+  const pg = projectGroups.value.find(p => p.tdei_project_group_id === model.value)
   const name = pg?.name ?? selectedGroupName.value
   searchText.value = name
   if (pg) selectedGroupName.value = name
@@ -285,38 +290,58 @@ const onFocusOut = (e: FocusEvent) => {
   }
 }
 
+watch(
+  projectGroups,
+  (groups) => {
+    if (groups.length > 0) {
+      const pgId = model.value as string | undefined
+      if (!pgId || !groups.some(pg => pg.tdei_project_group_id === pgId)) {
+        model.value = groups[0]?.tdei_project_group_id
+      }
+      const selected = groups.find(pg => pg.tdei_project_group_id === model.value)
+      if (selected && !isOpen.value) {
+        searchText.value = selected.name
+        selectedGroupName.value = selected.name
+      }
+    }
+  },
+  { immediate: true },
+)
+
 onMounted(async () => {
   // Show cached name immediately before the API call completes
   if (model.value && loadCachedName(model.value as string)) {
     applyCachedName()
   }
 
-  await loadGroups(true)
+  if (!props.options) {
+    await loadGroups(true)
 
-  if (projectGroups.value.length > 0) {
-    const selected = projectGroups.value.find(pg => pg.id === model.value)
-    if (selected) {
-      searchText.value = selected.name
-      selectedGroupName.value = selected.name
-    } else if (model.value && loadCachedName(model.value as string)) {
-      // Group is beyond page 1 — use the cached name for display
-      applyCachedName()
-    } else if (model.value) {
-      // model is set but name is unknown — paginate until the group is found
-      while (hasMore.value) {
-        await loadGroups()
-        const found = projectGroups.value.find(pg => pg.id === model.value)
-        if (found) {
-          searchText.value = found.name
-          selectedGroupName.value = found.name
-          break
+    if (fetchedGroups.value.length > 0) {
+      const selected = fetchedGroups.value.find(pg => pg.tdei_project_group_id === model.value)
+      if (selected) {
+        searchText.value = selected.name
+        selectedGroupName.value = selected.name
+      } else if (model.value && loadCachedName(model.value as string)) {
+        // Group is beyond page 1 — use the cached name for display
+        applyCachedName()
+      } else if (model.value) {
+        // model is set but name is unknown — paginate until the group is found
+        while (hasMore.value) {
+          await loadGroups()
+          const found = fetchedGroups.value.find(pg => pg.tdei_project_group_id === model.value)
+          if (found) {
+            searchText.value = found.name
+            selectedGroupName.value = found.name
+            break
+          }
         }
+      } else if (!model.value) {
+        const first = fetchedGroups.value[0]!
+        model.value = first.tdei_project_group_id
+        searchText.value = first.name
+        selectedGroupName.value = first.name
       }
-    } else if (!model.value) {
-      const first = projectGroups.value[0]!
-      model.value = first.id
-      searchText.value = first.name
-      selectedGroupName.value = first.name
     }
   }
 })

--- a/components/dashboard/DetailsTable.vue
+++ b/components/dashboard/DetailsTable.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="table-responsive border-top">
-    <table class="table table-striped mb-0">
+  <div class="table-responsive border-top mb-0">
+    <table class="table table-striped">
       <tbody>
         <tr>
           <th><app-icon variant="schedule" />Created At</th>
@@ -9,6 +9,41 @@
         <tr>
           <th><app-icon variant="person_outline" />Created By</th>
           <td>{{ workspace.createdByName }}</td>
+        </tr>
+        <tr>
+          <th><app-icon variant="badge" />My Role</th>
+          <td>
+            <span
+              v-if="workspace.role === 'lead'"
+              class="badge bg-dark text-uppercase"
+            >
+              <app-icon variant="star" /> Owner
+            </span>
+            <span
+              v-else-if="workspace.role === 'validator'"
+              class="badge bg-dark text-uppercase"
+            >
+              <app-icon variant="task_alt" /> Validator
+            </span>
+            <span
+              v-else
+              class="badge bg-secondary text-uppercase"
+            >
+              <app-icon variant="person" /> Member
+            </span>
+            <span
+              v-if="isPoc"
+              class="badge bg-warning text-dark text-uppercase ms-1"
+            >
+              <app-icon variant="local_police" /> POC
+            </span>
+            <span
+              v-else-if="isDataGenerator"
+              class="badge bg-warning text-dark text-uppercase ms-1"
+            >
+              <app-icon variant="offline_bolt" /> Data Generator
+            </span>
+          </td>
         </tr>
         <tr>
           <th><app-icon variant="phonelink_setup" />App Access</th>
@@ -42,12 +77,19 @@
 </template>
 
 <script setup lang="ts">
-const props = defineProps({
-  workspace: {
-    type: Object,
-    required: true
-  }
-});
+import type { Workspace } from '~/types/workspaces';
+
+interface Props {
+  workspace: Workspace;
+  myTdeiRoles: string[];
+}
+
+const props = defineProps<Props>();
+
+const isPoc = computed(() => props.myTdeiRoles.includes('poc'));
+const isDataGenerator = computed(() =>
+  props.myTdeiRoles.includes(`${props.workspace.type}_data_generator`),
+);
 </script>
 
 <style lang="scss">

--- a/components/dashboard/Toolbar.vue
+++ b/components/dashboard/Toolbar.vue
@@ -52,8 +52,8 @@
         <app-icon variant="settings" size="24" no-margin />
         <span class="d-none d-sm-inline ms-2">Settings</span>
       </nuxt-link>
-    </div>
-  </div>
+    </div><!-- .btn-group -->
+  </div><!-- .btn-toolbar -->
 </template>
 
 <script setup lang="ts">

--- a/components/dashboard/WorkspaceItem.vue
+++ b/components/dashboard/WorkspaceItem.vue
@@ -9,10 +9,25 @@
       <app-icon v-else variant="lock" />
       App
     </span>
+
+    <span
+      v-if="workspace.role === 'lead'"
+      class="badge bg-dark ms-2"
+    >
+      <app-icon variant="star" /> {{ ROLE_LABELS.lead }}
+    </span>
+    <span
+      v-else-if="workspace.role === 'validator'"
+      class="badge bg-dark ms-2"
+    >
+      <app-icon variant="task_alt" /> {{ ROLE_LABELS.validator }}
+    </span>
   </button>
 </template>
 
 <script setup lang="ts">
+import { ROLE_LABELS } from '~/util/roles';
+
 const props = defineProps({
   workspace: {
     type: Object,

--- a/components/review/Toolbar.vue
+++ b/components/review/Toolbar.vue
@@ -45,16 +45,27 @@
         {{ props.item.commentCount }}
       </span>
     </button>
-    <button
-      v-show="props.item.isFeedback"
-      class="btn btn-sm btn-success ms-2"
+    <BPopover
+      content="Only validators and owners can resolve feedback"
+      placement="bottom"
+      :manual="isValidator"
     >
-      <app-icon
-        variant="check"
-        no-margin
-      />
-      <span class="d-none d-sm-inline ms-2">Mark as Resolved</span>
-    </button>
+      <template #target>
+        <div class="d-inline-block ms-2">
+          <button
+            v-show="props.item.isFeedback && !props.item.isResolved"
+            class="btn btn-sm btn-success"
+            :disabled="!isValidator"
+          >
+            <app-icon
+              variant="check"
+              no-margin
+            />
+            <span class="d-none d-sm-inline ms-2">Mark as Resolved</span>
+          </button>
+        </div>
+      </template>
+    </BPopover>
   </nav>
 </template>
 
@@ -66,6 +77,7 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+const { isValidator } = useWorkspaceRole();
 
 const emit = defineEmits(['edit']);
 const showDetails = defineModel<boolean>('showDetails');

--- a/components/settings/Nav.vue
+++ b/components/settings/Nav.vue
@@ -7,8 +7,14 @@
       General
     </settings-nav-link>
     <settings-nav-link
+      to="/members"
+      icon="admin_panel_settings"
+    >
+      Members
+    </settings-nav-link>
+    <settings-nav-link
       to="/teams"
-      icon="group"
+      icon="diversity_3"
     >
       Teams
     </settings-nav-link>

--- a/components/settings/panel/Apps.vue
+++ b/components/settings/panel/Apps.vue
@@ -8,6 +8,16 @@
         External Apps
       </h3>
 
+      <b-alert
+        v-if="!isLead"
+        variant="info"
+        show
+        class="mb-3"
+      >
+        <app-icon variant="info" />
+        Only workspace owners can change external app settings.
+      </b-alert>
+
       <div class="form-check form-switch">
         <label class="form-check-label">
           <input
@@ -16,6 +26,7 @@
             class="form-check-input"
             :true-value="1"
             :false-value="0"
+            :disabled="!isLead"
           >
           Publish this workspace for external apps
         </label>
@@ -36,6 +47,7 @@
             type="radio"
             name="longFormQuestType"
             value="JSON"
+            :disabled="!isLead"
           >
         </label>
       </div>
@@ -48,6 +60,7 @@
             type="radio"
             name="longFormQuestType"
             value="URL"
+            :disabled="!isLead"
           >
         </label>
       </div>
@@ -61,6 +74,7 @@
             :class="{ 'drag-over': isDraggingQuest }"
             rows="5"
             placeholder="Optional"
+            :disabled="!isLead"
             @dragover.prevent="isDraggingQuest = true"
             @dragleave.prevent="isDraggingQuest = false"
             @drop.prevent="onQuestFileDrop"
@@ -96,6 +110,7 @@
             type="text"
             class="form-control"
             placeholder="https://..."
+            :disabled="!isLead"
           >
         </label>
         <div
@@ -131,6 +146,7 @@
       <button
         type="submit"
         class="btn btn-primary"
+        :disabled="!isLead"
       >
         Save
       </button>
@@ -157,6 +173,7 @@ const longFormQuestSchemaUrl = import.meta.env.VITE_LONG_FORM_QUEST_SCHEMA;
 const longFormQuestExampleUrl = import.meta.env.VITE_LONG_FORM_QUEST_EXAMPLE_URL;
 
 const workspace = inject<Workspace>('workspace')!;
+const { isLead } = useWorkspaceRole();
 
 const [longFormQuestSettings] = await Promise.all([
   workspacesClient.getLongFormQuestSettings(workspace.id),

--- a/components/settings/panel/Delete.vue
+++ b/components/settings/panel/Delete.vue
@@ -5,6 +5,16 @@
         Delete Workspace
       </h3>
 
+      <b-alert
+        v-if="!isLead"
+        variant="info"
+        show
+        class="mb-3"
+      >
+        <app-icon variant="info" />
+        Only workspace owners can delete the workspace.
+      </b-alert>
+
       <p>
         Deleting a workspace is permanent. This action will not remove any
         TDEI datasets outside of Workspaces.
@@ -12,7 +22,7 @@
 
       <button
         class="btn btn-outline-danger mb-3"
-        :disabled="accepted"
+        :disabled="!isLead || accepted"
         @click="acceptDelete"
       >
         I understand, and I want to delete this workspace
@@ -30,7 +40,7 @@
 
         <button
           class="btn btn-danger"
-          :disabled="attestation !== 'delete'"
+          :disabled="!isLead || attestation !== 'delete'"
           @click="submitDelete"
         >
           Delete this workspace
@@ -48,18 +58,27 @@ import { workspacesClient } from '~/services/index';
 import type { Workspace } from '~/types/workspaces';
 
 const workspace = inject<Workspace>('workspace')!;
+const { isLead } = useWorkspaceRole();
 
 const accepted = ref(false);
 const attestation = ref('');
 const input = useTemplateRef<HTMLInputElement>('input');
 
 async function acceptDelete() {
+  if (!isLead.value) {
+    return;
+  }
+
   accepted.value = true;
   await nextTick();
   input.value!.focus();
 }
 
 async function submitDelete() {
+  if (!isLead.value) {
+    return;
+  }
+
   await workspacesClient.deleteWorkspace(workspace.id);
   navigateTo('/dashboard');
 }

--- a/components/settings/panel/General.vue
+++ b/components/settings/panel/General.vue
@@ -1,18 +1,29 @@
 <template>
   <section class="card mb-4">
     <div class="card-body">
+      <b-alert
+        v-if="!isLead"
+        variant="info"
+        show
+        class="mb-3"
+      >
+        <app-icon variant="info" />
+        Only workspace owners can rename the workspace.
+      </b-alert>
       <form @submit.prevent="rename">
         <label class="d-block mb-3">
           Workspace Title
           <input
             v-model.trim="workspaceName"
             class="form-control"
+            :disabled="!isLead"
           >
         </label>
 
         <button
           type="submit"
           class="btn btn-primary"
+          :disabled="!isLead"
         >
           Rename
         </button>
@@ -28,6 +39,7 @@ import { workspacesClient } from '~/services/index';
 import type { Workspace } from '~/types/workspaces';
 
 const workspace = inject<Workspace>('workspace')!;
+const { isLead } = useWorkspaceRole();
 const workspaceName = ref(workspace.title);
 
 async function rename() {

--- a/components/settings/panel/Imagery.vue
+++ b/components/settings/panel/Imagery.vue
@@ -8,6 +8,16 @@
         Custom Imagery
       </h3>
 
+      <b-alert
+        v-if="!isLead"
+        variant="info"
+        show
+        class="mb-3"
+      >
+        <app-icon variant="info" />
+        Only workspace owners can change imagery settings.
+      </b-alert>
+
       <label class="d-block form-label">
         Imagery JSON Definition
         <textarea
@@ -16,6 +26,7 @@
           :class="{ 'drag-over': isDraggingImagery }"
           rows="5"
           placeholder="Optional"
+          :disabled="!isLead"
           @dragover.prevent="isDraggingImagery = true"
           @dragleave.prevent="isDraggingImagery = false"
           @drop.prevent="onImageryFileDrop"
@@ -51,6 +62,7 @@
       <button
         type="submit"
         class="btn btn-primary"
+        :disabled="!isLead"
       >
         Save
       </button>
@@ -73,6 +85,7 @@ import { handleFileDrop, validateJson } from '~/util/schema';
 import type { Workspace } from '~/types/workspaces';
 
 const workspace = inject<Workspace>('workspace')!;
+const { isLead } = useWorkspaceRole();
 
 const imagerySchemaUrl = import.meta.env.VITE_IMAGERY_SCHEMA;
 const imageryExampleUrl = import.meta.env.VITE_IMAGERY_EXAMPLE_URL;
@@ -114,7 +127,7 @@ async function saveImageryConfiguration() {
   }
 
   try {
-    workspacesClient.updateWorkspace(workspace.id, {
+    await workspacesClient.updateWorkspace(workspace.id, {
       imageryListDef: imageryResult.data,
     });
     imagerySaveStatus.value = { type: 'success', message: 'Changes saved.' };

--- a/components/settings/panel/Imagery.vue
+++ b/components/settings/panel/Imagery.vue
@@ -90,17 +90,19 @@ const { isLead } = useWorkspaceRole();
 const imagerySchemaUrl = import.meta.env.VITE_IMAGERY_SCHEMA;
 const imageryExampleUrl = import.meta.env.VITE_IMAGERY_EXAMPLE_URL;
 
-let imageryListDefInit = '';
-
-if (Array.isArray(workspace.imageryListDef)) {
-  imageryListDefInit = JSON.stringify(workspace.imageryListDef, null, 2);
-}
-
 const imagerySchema = ref<object | undefined>();
-const imageryListDef = ref(imageryListDefInit);
+const imageryListDef = ref('');
 const imageryError = ref<string | null>(null);
 const imagerySaveStatus = ref<{ type: 'success' | 'error'; message: string } | null>(null);
 const isDraggingImagery = ref(false);
+
+onMounted(async () => {
+  const settings = await workspacesClient.getImagerySettings(workspace.id);
+
+  if (Array.isArray(settings.definition)) {
+    imageryListDef.value = JSON.stringify(settings.definition, null, 2);
+  }
+});
 
 function clearImageryMessages() {
   imageryError.value = null;
@@ -127,8 +129,8 @@ async function saveImageryConfiguration() {
   }
 
   try {
-    await workspacesClient.updateWorkspace(workspace.id, {
-      imageryListDef: imageryResult.data,
+    await workspacesClient.saveImageryDefSettings(workspace.id, {
+      definition: imageryResult.data,
     });
     imagerySaveStatus.value = { type: 'success', message: 'Changes saved.' };
   }

--- a/components/teams/Item.vue
+++ b/components/teams/Item.vue
@@ -21,6 +21,7 @@
     </div>
     <div class="align-self-center flex-shrink-0 ms-auto">
       <button
+        v-if="props.isLead"
         class="btn px-1"
         @click="openSettings"
       >
@@ -41,6 +42,7 @@
         <span class="visually-hidden">View QR Code</span>
       </button>
       <button
+        v-if="props.isLead"
         class="btn ms-1 px-1 text-danger"
         @click="remove"
       >
@@ -59,6 +61,7 @@ import type { WorkspaceTeam } from '~/types/workspaces';
 
 interface Props {
   team: WorkspaceTeam;
+  isLead: boolean;
 }
 
 const props = defineProps<Props>();

--- a/components/teams/MembersDialog.vue
+++ b/components/teams/MembersDialog.vue
@@ -29,6 +29,7 @@
 
         <div class="align-self-center flex-shrink-0 ms-auto">
           <button
+            v-if="isLead"
             class="btn ms-1 px-1 py-0 text-danger"
             @click="remove(user)"
           >
@@ -58,6 +59,7 @@ interface Props {
 
 const props = defineProps<Props>();
 const workspace = inject<Workspace>('workspace')!;
+const { isLead } = useWorkspaceRole();
 const { create } = useModal();
 const modal = useTemplateRef<ComponentExposed<typeof BModal>>('modal');
 
@@ -85,6 +87,10 @@ async function onTeamChange(team?: WorkspaceTeam) {
 }
 
 async function remove(user: User) {
+  if (!isLead.value) {
+    return;
+  }
+
   const value = await create({
     body: `Remove ${user.display_name} from "${props.team!.name}"?`,
     title: 'Remove Team Member',

--- a/composables/useWorkspaceRole.ts
+++ b/composables/useWorkspaceRole.ts
@@ -1,0 +1,25 @@
+import type { Workspace, WorkspaceRole } from '~/types/workspaces';
+
+/**
+ * Provides role-checking helpers for the current workspace. Requires a parent
+ * component to call:
+ *
+ *   provide('workspace', workspace).
+ *
+ */
+export function useWorkspaceRole() {
+  const workspace = inject<Workspace>('workspace');
+
+  if (import.meta.dev && !workspace) {
+    console.warn(
+      'useWorkspaceRole: no workspace injected.',
+      'A parent component must call provide("workspace", workspace).',
+    );
+  }
+
+  const role = computed<WorkspaceRole | undefined>(() => workspace?.role);
+  const isLead = computed(() => role.value === 'lead');
+  const isValidator = computed(() => role.value === 'validator' || isLead.value);
+
+  return { role, isLead, isValidator };
+}

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -30,20 +30,29 @@
       </div><!-- .col-md -->
 
       <div class="col-md workspace-details-col">
-        <div class="card" :style="currentWorkspace ? '' : 'visibility: hidden'">
+        <div
+          v-if="currentWorkspace"
+          class="card"
+        >
           <nav class="card-header">
             <dashboard-toolbar :workspace="currentWorkspace" />
           </nav>
 
           <dashboard-map :workspace="currentWorkspace" @center-loaded="onCenterLoaded" />
-          <dashboard-details-table :workspace="currentWorkspace" />
+          <dashboard-details-table
+            :workspace="currentWorkspace"
+            :my-tdei-roles="currentWorkspaceTdeiRoles"
+          />
         </div><!-- .card -->
       </div><!-- .col-md -->
     </div><!-- .row -->
   </app-page>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
+import { tdeiUserClient, workspacesClient } from '~/services/index';
+import { compareWorkspaceCreatedAtDesc } from '~/services/workspaces';
+
 const STORAGE_KEY_PROJECT_GROUP = 'tdei-selected-project-group';
 const STORAGE_KEY_WORKSPACE = 'tdei-selected-workspace';
 
@@ -73,20 +82,28 @@ function setLastWorkspaceId(id: number) {
     sessionStorage.setItem(STORAGE_KEY_WORKSPACE, String(id));
   } catch { /* silently fail */ }
 }
-</script>
-
-<script setup lang="ts">
-import { workspacesClient } from '~/services/index';
-import { compareWorkspaceCreatedAtDesc } from '~/services/workspaces';
 
 const route = useRoute();
 
-const workspaces = (await workspacesClient.getMyWorkspaces()).sort(compareWorkspaceCreatedAtDesc);
+const [workspaces, { items: myProjectGroups }] = await Promise.all([
+  workspacesClient.getMyWorkspaces().then(ws => ws.sort(compareWorkspaceCreatedAtDesc)),
+  tdeiUserClient.getMyProjectGroups(1, '', 10000),
+]);
+const rolesByProjectGroup = new Map(myProjectGroups.map(pg => [pg.tdei_project_group_id, pg.roles]));
 const workspacesByProjectGroup = Map.groupBy(workspaces, w => w.tdeiProjectGroupId);
 
 const currentProjectGroup = ref(getLastProjectGroupId());
-const currentWorkspace = ref({});
-const currentWorkspaces = computed(() => workspacesByProjectGroup.get(currentProjectGroup.value));
+const currentWorkspace = ref<Workspace>();
+const currentWorkspaces = computed(() =>
+  currentProjectGroup.value
+    ? workspacesByProjectGroup.get(currentProjectGroup.value)
+    : undefined,
+);
+const currentWorkspaceTdeiRoles = computed(() =>
+  currentWorkspace.value
+    ? rolesByProjectGroup.get(currentWorkspace.value.tdeiProjectGroupId) ?? []
+    : [],
+);
 
 for (const w of workspaces) {
   if (w.tdeiMetadata?.length > 0) {
@@ -130,16 +147,17 @@ function autoSelectPreferredView() {
 
 async function onCurrentWorkspacesChange(val) {
   if (val?.length > 0) {
-    if (val[0].tdeiProjectGroupId !== currentWorkspace.value.tdeiProjectGroupId) {
+    if (val[0].tdeiProjectGroupId !== currentWorkspace.value?.tdeiProjectGroupId) {
       await selectWorkspace(val[0]);
     }
-  } else {
-    currentWorkspace.value = {};
+  }
+  else {
+    currentWorkspace.value = undefined;
   }
 }
 
 function onCenterLoaded(center) {
-  currentWorkspace.value.center = center;
+  currentWorkspace.value!.center = center;
 }
 
 async function selectWorkspace(workspace) {

--- a/pages/workspace/[id]/export/tdei.vue
+++ b/pages/workspace/[id]/export/tdei.vue
@@ -3,11 +3,42 @@
     <div class="text-center mt-5">
       <app-icon variant="drive_folder_upload" size="48" />
     </div>
-    <h1 class="mb-5 text-center">Export Workspace to TDEI</h1>
+    <h1 class="mb-5 text-center">
+      Export Workspace to the TDEI
+    </h1>
 
     <div class="row row-cols-1 row-cols-md-2 g-4">
       <div class="col mx-auto">
-        <div v-if="workspace.type === 'pathways' && !workspace.tdeiRecordId" class="card">
+        <div
+          v-if="!canExport"
+          class="card"
+        >
+          <div class="card-body">
+            <p>
+              You don't have permission to export this workspace to the TDEI.
+              Exporting requires a <strong>POC</strong> or
+              <strong>{{ dataGeneratorRole }}</strong> role
+              in at least one TDEI project group.
+            </p>
+            <p class="mb-0">
+              Contact your TDEI project group POC to request the appropriate role.
+            </p>
+          </div>
+          <div class="card-footer">
+            <nuxt-link
+              to="../export"
+              class="btn btn-primary"
+            >
+              <app-icon
+                variant="arrow_circle_left"
+                no-margin
+              />
+              Go back
+            </nuxt-link>
+          </div>
+        </div>
+
+        <div v-else-if="workspace.type === 'pathways' && !workspace.tdeiRecordId" class="card">
           <div class="card-body">
             <p>
               This GTFS Pathways workspace is not derived from a TDEI dataset and
@@ -15,7 +46,10 @@
             </p>
           </div>
           <div class="card-footer">
-            <nuxt-link to="../" class="btn btn-primary">
+            <nuxt-link
+              to="../export"
+              class="btn btn-primary"
+            >
               <app-icon variant="arrow_circle_left" no-margin />
               Go back
             </nuxt-link>
@@ -30,7 +64,10 @@
             </label>
             <label class="d-block mt-3">
               Project Group
-              <project-group-picker v-model="workspace.tdeiProjectGroupId" />
+              <project-group-picker
+                v-model="workspace.tdeiProjectGroupId"
+                :options="eligibleProjectGroups"
+              />
             </label>
             <label class="d-block mt-3">
               Service
@@ -75,7 +112,7 @@
 </template>
 
 <script setup lang="ts">
-import { osmClient, tdeiClient, workspacesClient } from '~/services/index'
+import { osmClient, tdeiClient, tdeiUserClient, workspacesClient } from '~/services/index';
 import { TdeiExporter, TdeiExporterContext } from '~/services/export/tdei'
 import { toast } from 'vue3-toastify';
 import 'vue3-toastify/dist/index.css';
@@ -84,8 +121,24 @@ const context = reactive(new TdeiExporterContext());
 const exporter = new TdeiExporter(tdeiClient, osmClient, context);
 
 const route = useRoute();
-const workspaceId = route.params.id;
-const workspace = reactive(await workspacesClient.getWorkspace(workspaceId));
+const workspaceId = Number(route.params.id);
+
+const [workspace, myProjectGroups] = await Promise.all([
+  workspacesClient.getWorkspace(workspaceId),
+  tdeiUserClient.getMyProjectGroups(),
+]);
+
+const dataGeneratorRole = `${workspace.type}_data_generator`;
+const eligibleProjectGroups = myProjectGroups.filter(pg =>
+  pg.roles.includes('poc') || pg.roles.includes(dataGeneratorRole),
+);
+const canExport = eligibleProjectGroups.length > 0;
+
+// Default to the workspace's own PG if eligible, otherwise first eligible PG:
+if (canExport && !eligibleProjectGroups.some(pg => pg.tdei_project_group_id === workspace.tdeiProjectGroupId)) {
+  workspace.tdeiProjectGroupId = eligibleProjectGroups[0]!.tdei_project_group_id;
+}
+
 const oldMetadata = workspace.tdeiMetadata ? JSON.parse(workspace.tdeiMetadata) : {};
 
 const datasetName = ref(workspace.title);

--- a/pages/workspace/[id]/export/tdei.vue
+++ b/pages/workspace/[id]/export/tdei.vue
@@ -162,7 +162,7 @@ async function upload() {
 
   if (jobId) {
     // TODO: show a more helpful message
-    toast.info(`TDEI import job ${jobId} created sucessfully.`);
+    toast.info(`TDEI import job ${jobId} created successfully.`);
     navigateTo('/dashboard');
   }
 }

--- a/pages/workspace/[id]/review.vue
+++ b/pages/workspace/[id]/review.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { reviewManager } from '~/services/index';
+import { reviewManager, workspacesClient } from '~/services/index';
 
 import type ReviewMap from '~/components/review/Map.vue';
 import type { ReviewListItem } from '~/services/review.ts';
@@ -60,6 +60,9 @@ import type { AdiffAction } from '~/types/adiff';
 
 const route = useRoute();
 const workspaceId = Number(route.params.id);
+
+const workspace = await workspacesClient.getWorkspace(workspaceId);
+provide('workspace', workspace);
 
 const reviewList = reviewManager.getList(workspaceId);
 const filter = reactive(reviewManager.getFilter());

--- a/pages/workspace/[id]/settings/members.vue
+++ b/pages/workspace/[id]/settings/members.vue
@@ -1,0 +1,275 @@
+<template>
+  <b-col lg="8">
+    <b-alert
+      v-if="accessDenied"
+      variant="info"
+      show
+      class="mb-4"
+    >
+      <app-icon variant="info" />
+      You need a TDEI POC role in this project group to view and manage
+      workspace member roles.
+    </b-alert>
+
+    <h3 class="border-bottom pb-2">
+      Project Group Admins
+      <app-icon
+        variant="local_police"
+        size="24"
+      />
+    </h3>
+    <p class="mt-3 mb-4">
+      TDEI project group admins (POCs) have full control of the workspace and
+      all workspace settings.
+    </p>
+    <b-list-group
+      v-if="pocs.length"
+      class="mb-5"
+    >
+      <b-list-group-item
+        v-for="m in pocs"
+        :key="m.user_id"
+        class="d-flex align-items-center"
+      >
+        <div class="me-auto">
+          <app-icon
+            variant="person"
+            class="d-none d-sm-inline"
+          />
+          {{ m.first_name }} {{ m.last_name }}
+        </div>
+        <b-badge>
+          <app-icon variant="lock" /> poc
+        </b-badge>
+      </b-list-group-item>
+    </b-list-group>
+    <b-alert
+      v-else
+      class="mb-5"
+      variant="light"
+      show
+    >
+      <app-icon variant="info" />
+      No one has a TDEI POC role in this project group.
+    </b-alert>
+
+    <h3 class="border-bottom pb-2">
+      Data Generators
+      <app-icon
+        variant="offline_bolt"
+        size="24"
+      />
+    </h3>
+    <p class="mt-3 mb-4">
+      Members with a TDEI data generator role can export workspace data to the
+      TDEI.
+    </p>
+    <b-list-group
+      v-if="generators.length"
+      class="mb-5"
+    >
+      <b-list-group-item
+        v-for="m in generators"
+        :key="m.user_id"
+        class="d-flex align-items-center"
+      >
+        <div class="me-auto">
+          <app-icon
+            variant="person"
+            class="d-none d-sm-inline"
+          />
+          {{ m.first_name }} {{ m.last_name }}
+        </div>
+        <template
+          v-for="role in m.roles"
+          :key="role"
+        >
+          <b-badge
+            v-if="role.endsWith('_data_generator')"
+            class="ms-1"
+          >
+            <app-icon variant="lock" /> {{ formatDataGeneratorRole(role) }}
+          </b-badge>
+        </template>
+      </b-list-group-item>
+    </b-list-group>
+    <b-alert
+      v-else
+      class="mb-5"
+      variant="light"
+      show
+    >
+      <app-icon variant="info" />
+      No one has a TDEI data generator role in this project group.
+    </b-alert>
+
+    <h3 class="border-bottom pb-2">
+      Workspace Members
+      <app-icon
+        variant="edit_location_alt"
+        size="24"
+      />
+    </h3>
+    <p class="mt-3">
+      Members of the TDEI project group can access and modify data in this
+      workspace. Those with the following roles have additional privileges:
+    </p>
+    <ul class="mb-4">
+      <li><strong>Owner</strong> can review changesets and modify workspace settings</li>
+      <li><strong>Validator</strong> can review changesets</li>
+    </ul>
+    <b-list-group v-if="members.length">
+      <b-list-group-item
+        v-for="m in members"
+        :key="m.user_id"
+        class="d-flex align-items-center"
+      >
+        <div class="me-auto">
+          <app-icon
+            variant="person"
+            class="d-none d-sm-inline"
+          />
+          {{ m.first_name }} {{ m.last_name }}
+        </div>
+
+        <!-- Lead: functional role dropdown -->
+        <b-dropdown
+          v-if="isLead"
+          variant="light"
+          size="sm"
+          :text="roleLabel(m.localRole)"
+          placement="bottom-end"
+        >
+          <b-dropdown-item @click="setRole(m, 'lead')">
+            <app-icon
+              variant="check"
+              :class="m.localRole === 'lead' ? '' : 'invisible'"
+            />
+            Owner
+          </b-dropdown-item>
+          <b-dropdown-item @click="setRole(m, 'validator')">
+            <app-icon
+              variant="check"
+              :class="m.localRole === 'validator' ? '' : 'invisible'"
+            />
+            Validator
+          </b-dropdown-item>
+          <b-dropdown-item @click="setRole(m, undefined)">
+            <app-icon
+              variant="check"
+              :class="!m.localRole ? '' : 'invisible'"
+            />
+            Member
+          </b-dropdown-item>
+        </b-dropdown>
+
+        <!-- Non-lead: read-only role badge -->
+        <b-badge
+          v-else
+          variant="secondary"
+        >
+          {{ roleLabel(m.localRole) }}
+        </b-badge>
+      </b-list-group-item>
+    </b-list-group>
+    <b-alert
+      v-else
+      class="mb-5"
+      variant="light"
+      show
+    >
+      <app-icon variant="info" />
+      There are no unprivileged members in this project group.
+    </b-alert>
+  </b-col>
+</template>
+
+<script setup lang="ts">
+import { toast } from 'vue3-toastify';
+import { WorkspacesClientError } from '~/services/workspaces';
+import { TdeiUserClientError } from '~/services/tdei';
+import { tdeiUserClient, workspacesClient } from '~/services/index';
+import { ROLE_LABELS } from '~/util/roles';
+import type { Workspace, WorkspaceRole } from '~/types/workspaces';
+import type { TdeiUserItem } from '~/types/tdei';
+
+interface MemberEntry {
+  user_id: string;
+  first_name: string;
+  last_name: string;
+  localRole?: WorkspaceRole;
+}
+
+const workspace = inject<Workspace>('workspace')!;
+const { isLead } = useWorkspaceRole();
+
+let projectGroupUsers: TdeiUserItem[] = [];
+let accessDenied = false;
+
+try {
+  projectGroupUsers = await tdeiUserClient.getProjectGroupUsers(workspace.tdeiProjectGroupId);
+}
+catch (e) {
+  if (e instanceof TdeiUserClientError && e.response.status === 403) {
+    accessDenied = true;
+  }
+  else {
+    throw e;
+  }
+}
+
+const localRoleMap = new Map<string, WorkspaceRole>();
+
+if (isLead.value) {
+  const wsMembers = await workspacesClient.getWorkspaceMembers(workspace.id);
+  for (const m of wsMembers) {
+    localRoleMap.set(m.user.auth_uid, m.role);
+  }
+}
+
+const pocs = projectGroupUsers.filter(u => u.roles.includes('poc'));
+const generators = projectGroupUsers.filter(
+  u => u.roles.some((r: string) => r.endsWith('_data_generator')),
+);
+const members = ref<MemberEntry[]>(
+  projectGroupUsers
+    .filter((u: TdeiUserItem) => !u.roles?.includes('poc'))
+    .map((u: TdeiUserItem) => ({
+      user_id: u.user_id,
+      first_name: u.first_name,
+      last_name: u.last_name,
+      localRole: localRoleMap.get(u.user_id),
+    })),
+);
+
+function roleLabel(role?: WorkspaceRole): string {
+  return role ? ROLE_LABELS[role] : ROLE_LABELS.contributor;
+}
+
+function formatDataGeneratorRole(role: string) {
+  const index = role.indexOf('_');
+  return role.substring(0, index);
+}
+
+async function setRole(member: MemberEntry, role?: WorkspaceRole) {
+  if (role === member.localRole) return;
+
+  try {
+    if (!role) {
+      await workspacesClient.removeRole(workspace.id, member.user_id);
+    }
+    else {
+      await workspacesClient.assignRole(workspace.id, member.user_id, role);
+    }
+    member.localRole = role;
+  }
+  catch (e) {
+    if (e instanceof WorkspacesClientError && e.response.status === 404) {
+      toast.error('This member has never signed in to Workspaces and cannot be assigned a role yet.');
+    }
+    else {
+      toast.error(e instanceof Error ? e.message : 'Failed to update role');
+    }
+  }
+}
+</script>

--- a/pages/workspace/[id]/settings/teams/index.vue
+++ b/pages/workspace/[id]/settings/teams/index.vue
@@ -4,15 +4,34 @@
       <h3 class="mb-0">
         Teams
       </h3>
-      <b-button
-        variant="primary"
-        class="flex-shrink-0"
-        @click="openNewDialog"
+      <b-popover
+        content="Only workspace owners can create teams"
+        :manual="isLead"
       >
-        <app-icon variant="add" /> New Team
-      </b-button>
+        <template #target>
+          <div class="d-inline-block">
+            <b-button
+              variant="primary"
+              class="flex-shrink-0"
+              :disabled="!isLead"
+              @click="openNewDialog"
+            >
+              <app-icon variant="add" /> New Team
+            </b-button>
+          </div>
+        </template>
+      </b-popover>
     </div>
 
+    <b-alert
+      v-if="!isLead"
+      variant="info"
+      show
+      class="mb-3"
+    >
+      <app-icon variant="info" />
+      Only workspace owners can create, rename, or delete teams.
+    </b-alert>
     <b-alert
       v-if="!teams.length"
       variant="info"
@@ -27,6 +46,7 @@
         v-for="team in teams"
         :key="team.id"
         :team="team"
+        :is-lead="isLead"
         @join="openJoinDialog"
         @open-settings="openSettingsDialog"
         @remove="remove"
@@ -61,6 +81,7 @@ import type TeamsMembersDialog from '~/components/teams/MembersDialog.vue';
 import type TeamsSettingsDialog from '~/components/teams/SettingsDialog.vue';
 import type { WorkspaceTeam } from '~/types/workspaces';
 
+const { isLead } = useWorkspaceRole();
 const { create } = useModal();
 const route = useRoute();
 const workspaceId = Number(route.params.id);

--- a/services/tdei.ts
+++ b/services/tdei.ts
@@ -10,6 +10,7 @@ import type {
   TdeiProjectGroup,
   TdeiService,
   TdeiDatasetSummary,
+  TdeiUserItem,
 } from '~/types/tdei.ts';
 
 const MIN_TOKEN_REFRESH_MS = 10 * 1000;
@@ -455,8 +456,8 @@ export class TdeiUserClient extends BaseHttpClient implements ICancelableClient 
     return this.#auth;
   }
 
-  clone(signal?: AbortSignal) {
-    return new TdeiClient(this._baseUrl, this.#auth, signal ?? this._abortSignal);
+  clone(signal?: AbortSignal): TdeiUserClient {
+    return new TdeiUserClient(this._baseUrl, this.#tdeiClient, signal ?? this._abortSignal);
   }
 
   async getMyProjectGroups(pageNo: number = 1, searchText: string = '', pageSize: number = 10, sortBy: 'name' | 'created_at' = 'name'): Promise<{ items: TdeiProjectGroup[], total?: number }> {
@@ -472,11 +473,23 @@ export class TdeiUserClient extends BaseHttpClient implements ICancelableClient 
       const totalParsed = totalHeader !== null ? parseInt(totalHeader, 10) : NaN;
       const total = Number.isNaN(totalParsed) ? undefined : totalParsed;
       const items = (await response.json() as TdeiProjectGroupApiResponse[]) ?? [];
-      return { items: items.map(p => ({ id: p.tdei_project_group_id, name: p.project_group_name })), total };
+      return { items: items.map(p => ({
+        tdei_project_group_id: p.tdei_project_group_id,
+        name: p.project_group_name,
+        roles: p.roles ?? [],
+      })), total };
     } catch (e) {
       console.warn('getMyProjectGroups: failed to parse API response', e);
       return { items: [] };
     }
+  }
+
+  async getMyRolesForProjectGroup(projectGroupId: string, pgName: string): Promise<string[]> {
+    const params = new URLSearchParams({ searchText: pgName });
+    const response = await this._get(`project-group-roles/${this.#auth.subject}?${params}`);
+    const pgs = (await response.json()) as TdeiProjectGroupApiResponse[];
+
+    return pgs.find(p => p.tdei_project_group_id === projectGroupId)?.roles ?? [];
   }
 
   async getMyServices(projectGroupId: string, type: string = 'all'): Promise<TdeiService[]> {
@@ -484,6 +497,16 @@ export class TdeiUserClient extends BaseHttpClient implements ICancelableClient 
 
     return (await response.json() as TdeiServiceApiResponse[])
       .map(s => ({ id: s.tdei_service_id, name: s.service_name }));
+  }
+
+  async getProjectGroupUsers(projectGroupId: string): Promise<TdeiUserItem[]> {
+    const params = new URLSearchParams();
+    params.append('page_no', '1');
+    params.append('page_size', '10000');
+
+    const response = await this._get(`project-group/${projectGroupId}/users?${params}`);
+
+    return await response.json();
   }
 
   #setAuthHeader() {

--- a/services/workspaces.ts
+++ b/services/workspaces.ts
@@ -5,7 +5,8 @@ import { compareStringAsc } from '~/util/compare';
 import type { ICancelableClient } from '~/services/loading';
 import type { OsmApiClient } from '~/services/osm';
 import type { TdeiAuthStore, TdeiClient } from '~/services/tdei';
-import type { BoundingBox } from '~/types/bbox'
+import type { BoundingBox } from '~/types/bbox';
+import type { ImagerySettings } from '~/types/imagery';
 import type {
   QuestSettings,
   QuestSettingsPatch,
@@ -146,8 +147,14 @@ export class WorkspacesClient extends BaseHttpClient implements ICancelableClien
     await this.#newApi._patch(`workspaces/${id}/quests/long/settings`, settings);
   }
 
-  async saveImageryDefSettings(workspaceId: number, settings: object): Promise<void> {
-    await this.#newApi._patch(`workspaces/${workspaceId}/imagery/settings`, settings);
+  async getImagerySettings(id: WorkspaceId): Promise<ImagerySettings> {
+    const response = await this.#newApi._get(`workspaces/${id}/imagery/settings`);
+
+    return await response.json();
+  }
+
+  async saveImageryDefSettings(id: WorkspaceId, settings: object): Promise<void> {
+    await this.#newApi._patch(`workspaces/${id}/imagery/settings`, settings);
   }
 
   async getTeams(id: WorkspaceId): Promise<WorkspaceTeam[]> {

--- a/services/workspaces.ts
+++ b/services/workspaces.ts
@@ -13,7 +13,9 @@ import type {
   Workspace,
   WorkspaceCreation,
   WorkspaceId,
+  WorkspaceMember,
   WorkspacePatch,
+  WorkspaceRole,
   WorkspaceTeam,
 } from '~/types/workspaces';
 
@@ -75,7 +77,7 @@ export class WorkspacesClient extends BaseHttpClient implements ICancelableClien
   }
 
   async getMyWorkspaces(): Promise<Workspace[]> {
-    const response = await this._get('workspaces/mine');
+    const response = await this.#newApi._get('workspaces/mine');
     const workspaces = (await response.json()) ?? [];
 
     for (const workspace of workspaces) {
@@ -87,7 +89,7 @@ export class WorkspacesClient extends BaseHttpClient implements ICancelableClien
   }
 
   async getWorkspace(id: WorkspaceId): Promise<Workspace> {
-    const response = await this._get(`workspaces/${id}`);
+    const response = await this.#newApi._get(`workspaces/${id}`);
 
     return await response.json();
   }
@@ -100,17 +102,15 @@ export class WorkspacesClient extends BaseHttpClient implements ICancelableClien
     workspace.createdBy = this.#tdeiClient.auth.subject;
     workspace.createdByName = this.#tdeiClient.auth.displayName;
 
-    const workspaceResponse = await this._post('workspaces', workspace);
+    const workspaceResponse = await this.#newApi._post('workspaces', workspace);
     const workspaceId = (await workspaceResponse.json()).workspaceId;
     await this.#osmClient.createWorkspace(workspaceId);
 
     return workspaceId;
   }
 
-  async updateWorkspace(id: WorkspaceId, workspaceDetails: WorkspacePatch)
-    : Promise<void>
-  {
-    await this._patch(`workspaces/${id}`, workspaceDetails);
+  async updateWorkspace(id: WorkspaceId, workspaceDetails: WorkspacePatch): Promise<void> {
+    await this.#newApi._patch(`workspaces/${id}`, workspaceDetails);
   }
 
   async exportWorkspaceArchive(workspace: Workspace): Promise<Blob> {
@@ -131,25 +131,23 @@ export class WorkspacesClient extends BaseHttpClient implements ICancelableClien
 
   async deleteWorkspace(id: WorkspaceId): Promise<void> {
     await Promise.all([
-      this._delete(`workspaces/${id}`),
-      this.#osmClient.deleteWorkspace(id)
+      this.#newApi._delete(`workspaces/${id}`),
+      this.#osmClient.deleteWorkspace(id),
     ]);
   }
 
   async getLongFormQuestSettings(id: WorkspaceId): Promise<QuestSettings> {
-    const response = await this._get(`workspaces/${id}/quests/long/settings`);
+    const response = await this.#newApi._get(`workspaces/${id}/quests/long/settings`);
 
     return await response.json();
   }
 
-  async saveLongFormQuestSettings(id: WorkspaceId, settings: QuestSettingsPatch)
-    : Promise<void>
-  {
-    await this._patch(`workspaces/${id}/quests/long/settings`, settings);
+  async saveLongFormQuestSettings(id: WorkspaceId, settings: QuestSettingsPatch): Promise<void> {
+    await this.#newApi._patch(`workspaces/${id}/quests/long/settings`, settings);
   }
 
   async saveImageryDefSettings(workspaceId: number, settings: object): Promise<void> {
-    await this._patch(`workspaces/${workspaceId}/imagery/settings`, settings);
+    await this.#newApi._patch(`workspaces/${workspaceId}/imagery/settings`, settings);
   }
 
   async getTeams(id: WorkspaceId): Promise<WorkspaceTeam[]> {
@@ -200,6 +198,28 @@ export class WorkspacesClient extends BaseHttpClient implements ICancelableClien
 
   async removeFromTeam(id: WorkspaceId, teamId: number, userId: number): Promise<void> {
     await this.#newApi._delete(`workspaces/${id}/teams/${teamId}/members/${userId}`);
+  }
+
+  async getWorkspaceMembers(id: WorkspaceId): Promise<WorkspaceMember[]> {
+    const response = await this.#newApi._get(`workspaces/${id}/users`);
+    const items: Array<User & { role: WorkspaceRole }> = await response.json();
+    return items.map(item => ({
+      user: {
+        id: item.id,
+        auth_uid: item.auth_uid,
+        email: item.email,
+        display_name: item.display_name,
+      },
+      role: item.role,
+    }));
+  }
+
+  async assignRole(id: WorkspaceId, userUuid: string, role: WorkspaceRole): Promise<void> {
+    await this.#newApi._put(`workspaces/${id}/users/${userUuid}/role`, { role });
+  }
+
+  async removeRole(id: WorkspaceId, userUuid: string): Promise<void> {
+    await this.#newApi._delete(`workspaces/${id}/users/${userUuid}`);
   }
 
   #setAuthHeader() {

--- a/types/imagery.ts
+++ b/types/imagery.ts
@@ -1,0 +1,35 @@
+// Each ring is an array of [lon, lat] pairs. The first and last elements must
+// be equal (closed):
+type LinearRing = [number, number][];
+
+type ImagerySourceType = 'tms' | 'wmts' | 'xyz';
+
+interface ImagerySourceAttribution {
+  required: boolean;
+  text: string;
+  url: string;
+}
+
+interface ImagerySourceExtent {
+  max_zoom: number;
+  polygon: LinearRing[];
+}
+
+export interface ImagerySource {
+  attribution: ImagerySourceAttribution;
+  description: string;
+  extent: ImagerySourceExtent;
+  icon: string;
+  id: string;
+  name: string;
+  type: ImagerySourceType;
+  url: string;
+}
+
+export interface ImagerySettings {
+  workspace_id: number;
+  definition: ImagerySource[] | null;
+  modifiedAt: string;
+  modifiedBy: string;
+  modifiedByName: string;
+}

--- a/types/tdei.ts
+++ b/types/tdei.ts
@@ -1,7 +1,19 @@
+export type TdeiRoleAssignment = string;
+
 /** Shape returned by the TDEI project-group-roles API */
 export interface TdeiProjectGroupApiResponse {
   tdei_project_group_id: string;
   project_group_name: string;
+  roles?: string[];
+}
+
+export interface TdeiProjectGroupItem {
+  tdei_project_group_id: string;
+  name: string;
+}
+
+export interface TdeiProjectGroup extends TdeiProjectGroupItem {
+  roles: TdeiRoleAssignment[];
 }
 
 /** Shape returned by the TDEI service API */
@@ -29,19 +41,8 @@ export interface TdeiDatasetApiResponse {
   };
 }
 
-export interface TdeiProjectGroupItem {
-  tdei_project_group_id: string;
-  name: string;
-}
-
 export interface TdeiDatasetItem {
   tdei_dataset_id: string;
-  name: string;
-}
-
-/** Normalized project group used throughout the UI */
-export interface TdeiProjectGroup {
-  id: string;
   name: string;
 }
 
@@ -56,6 +57,16 @@ export interface TdeiDatasetSummary {
   id: string;
   name: string;
   version?: string;
+}
+
+export interface TdeiUserItem {
+  user_id: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  username: string;
+  phone: string;
+  roles: TdeiRoleAssignment[];
 }
 
 export interface TdeiFeedback {

--- a/types/workspaces.ts
+++ b/types/workspaces.ts
@@ -1,6 +1,7 @@
 export type WorkspaceId = number;
 export type WorkspaceType = 'osw' | 'pathways';
 export type WorkspaceAppAccess = 0 | 1 | 2;
+export type WorkspaceRole = 'lead' | 'validator' | 'contributor';
 
 export interface Workspace {
   id: WorkspaceId;
@@ -16,6 +17,7 @@ export interface Workspace {
   createdByName: string;
   externalAppAccess: WorkspaceAppAccess;
   kartaViewToken?: string;
+  role?: WorkspaceRole;
 }
 
 export interface WorkspaceCreation {
@@ -60,6 +62,10 @@ export interface WorkspaceTeam {
 export interface User {
   id: number;
   auth_uid: string;
-  email: string;
   display_name: string;
+}
+
+export interface WorkspaceMember {
+  user: User;
+  role: WorkspaceRole;
 }

--- a/util/roles.ts
+++ b/util/roles.ts
@@ -1,0 +1,7 @@
+import type { WorkspaceRole } from '~/types/workspaces'
+
+export const ROLE_LABELS: Record<WorkspaceRole, string> = {
+  lead: 'Owner',
+  validator: 'Validator',
+  contributor: 'Member',
+}


### PR DESCRIPTION
This sets up the UI for role management and integrates access controls into the Workspaces frontend.

Backend PR: https://github.com/TaskarCenterAtUW/workspaces-backend/pull/4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Members page in workspace settings for viewing/managing project-group admins, data generators, and workspace members; leads can change member roles and assign/remove roles via Workspaces API.
  * Permission-aware export flow to TDEI with selectable eligible project groups and project-group selection UI integration.
  * New composable useWorkspaceRole() exposing role, isLead, and isValidator to gate UI and actions across the app.
  * New Workspaces API methods: getWorkspaceMembers(id), assignRole(id, userUuid, role), removeRole(id, userUuid).
  * New TDEI user APIs: getMyProjectGroups(), getMyRolesForProjectGroup(projectGroupId, pgName), getProjectGroupUsers(projectGroupId).

* **UI/UX Improvements / Access Controls**
  * Site-wide role-aware UI gating: many settings panels (General, Imagery, Apps, Delete, Teams) and actions (create team, delete workspace, rename, save settings) now show informational alerts and disable inputs/buttons for non-leads.
  * Dashboard and workspace lists show a new "My Role" row and role badges (Owner/Lead, Validator, Member, POC, Data Generator) in DetailsTable, WorkspaceItem, and related components.
  * Review toolbar and feedback controls gated by validator/lead role logic.
  * Settings navigation updated to include a "Members" item; team items and team dialogs respect lead gating.

* **Types & Utilities**
  * New types: WorkspaceRole ('lead' | 'validator' | 'contributor'), WorkspaceMember, TdeiProjectGroup, TdeiUserItem, TdeiRoleAssignment.
  * New util ROLE_LABELS mapping WorkspaceRole to display labels.
  * ProjectGroupPicker updated to use tdei_project_group_id keys and accept options prop; ProjectGroup types and compare sorting used.

* **Service & Backend Integration**
  * services/workspaces.ts migrated various endpoints to a new API wrapper and added workspace member management methods.
  * services/tdei.ts expanded TDEI user client surface to return typed project groups and users and added role-query helpers.
  * Frontend pages/components updated to fetch and use TDEI project groups and roles for eligibility and UI defaults (export flow, dashboard grouping).

* **Notable Component Changes**
  * New pages/workspace/[id]/settings/members.vue added (major new file).
  * pages/dashboard.vue: reworked to model currentProjectGroup/currentWorkspace with typed bindings and pass currentWorkspaceTdeiRoles to details table.
  * pages/workspace/[id]/export/tdei.vue: adds project group selection, eligibility checks, and permission messaging.
  * Many components now consume useWorkspaceRole() and conditionalize UI and actions on isLead/isValidator.

Overall, this PR implements the initial permissions/roles system end-to-end: types and service methods, a composable for role derivation, UI wiring across dashboard and workspace settings, a members management page, and permission-aware flows for TDEI export and settings management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->