### PR TITLE
Add Rapid3 manager and split edit button with dropdown options for different versions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ VITE_OSM_URL=https://osm.workspaces-dev.sidewalks.washington.edu/
 # --- Embedded Editors ---------------------------------------------------------
 # Rapid editor (OSW editing) and Pathways editor (GTFS Pathways editing).
 # These are standalone apps hosted separately.
+VITE_RAPID3_URL=http://127.0.0.1:8080/dist/
 VITE_RAPID_URL=https://rapid.workspaces-dev.sidewalks.washington.edu/
 VITE_PATHWAYS_EDITOR_URL=https://pathways.workspaces-dev.sidewalks.washington.edu/
 

--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,8 @@ VITE_OSM_URL=https://osm.workspaces-dev.sidewalks.washington.edu/
 # --- Embedded Editors ---------------------------------------------------------
 # Rapid editor (OSW editing) and Pathways editor (GTFS Pathways editing).
 # These are standalone apps hosted separately.
-VITE_RAPID3_URL=http://127.0.0.1:8080/dist/
-VITE_RAPID_URL=https://rapid.workspaces-dev.sidewalks.washington.edu/
+VITE_RAPID3_URL=https://rapid.workspaces-dev.sidewalks.washington.edu/rapid3/
+VITE_RAPID_URL=https://rapid.workspaces-dev.sidewalks.washington.edu/rapid2/
 VITE_PATHWAYS_EDITOR_URL=https://pathways.workspaces-dev.sidewalks.washington.edu/
 
 # --- Schema / Example URLs (rarely need to change) ---------------------------

--- a/components/dashboard/Toolbar.vue
+++ b/components/dashboard/Toolbar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="btn-toolbar">
     <b-dropdown
-      v-if="isOsw"
+      v-if="isOsw && rapid3Available"
       split
       variant="dark"
       :split-to="editRoute"
@@ -57,6 +57,10 @@
 </template>
 
 <script setup lang="ts">
+import { rapid3Manager } from '~/services/index'
+
+const rapid3Available = !!rapid3Manager
+
 const props = defineProps({
   workspace: {
     type: Object,

--- a/components/dashboard/Toolbar.vue
+++ b/components/dashboard/Toolbar.vue
@@ -1,6 +1,26 @@
 <template>
   <div class="btn-toolbar">
-    <nuxt-link class="btn btn-dark" :to="editRoute">
+    <b-dropdown
+      v-if="isOsw"
+      split
+      variant="dark"
+      :split-to="editRoute"
+    >
+      <template #button-content>
+        <app-icon
+          variant="edit_location_alt"
+          size="24"
+        />
+        Edit
+      </template>
+      <b-dropdown-item :to="editRoute">
+        Rapid 2 (default)
+      </b-dropdown-item>
+      <b-dropdown-item :to="editRouteRapid3">
+        Rapid 3 (beta)
+      </b-dropdown-item>
+    </b-dropdown>
+    <nuxt-link v-else class="btn btn-dark" :to="editRoute">
       <app-icon variant="edit_location_alt" size="24" />
       Edit
     </nuxt-link>
@@ -54,9 +74,17 @@ const editHash = computed(() => {
   return `#map=${zoom}/${latitude}/${longitude}`;
 });
 
+const isOsw = computed(() => props.workspace.type === 'osw');
+
 const editRoute = computed(() => ({
   path: workspacePath('edit'),
   query: { datatype: props.workspace.type },
+  hash: editHash.value
+}));
+
+const editRouteRapid3 = computed(() => ({
+  path: workspacePath('edit'),
+  query: { datatype: props.workspace.type, editor: 'rapid3' },
   hash: editHash.value
 }));
 

--- a/pages/workspace/[id]/edit.vue
+++ b/pages/workspace/[id]/edit.vue
@@ -6,13 +6,17 @@
 </template>
 
 <script setup lang="ts">
-import { pathwaysManager, rapidManager } from '~/services/index'
+import { pathwaysManager, rapidManager, rapid3Manager } from '~/services/index'
 
 const route = useRoute()
 const workspaceId = route.params.id
 const datatype = route.query.datatype
+const editor = route.query.editor
 const editorContainer = ref(null)
-const manager = datatype === 'osw' ? rapidManager : pathwaysManager
+
+//const oswManager = (editor === 'rapid3' && rapid3Manager) ? rapid3Manager : rapidManager
+const oswManager = rapid3Manager  // testing - force Rapid v3
+const manager = datatype === 'osw' ? oswManager : pathwaysManager
 
 function onEditorLoaded() {
   editorContainer.value.appendChild(manager.containerNode)
@@ -20,6 +24,16 @@ function onEditorLoaded() {
 }
 
 onMounted(() => {
+  // If a different Rapid version is already loaded, hard-reload to swap.
+  // Only one version can occupy the global Rapid namespace at a time.
+  if (datatype === 'osw') {
+    const otherManager = manager === rapidManager ? rapid3Manager : rapidManager
+    if (otherManager?.loaded.value) {
+      window.location.reload()
+      return
+    }
+  }
+
   if (!manager.loaded.value) {
     watch(manager.loaded, (val) => {
       if (val) {

--- a/pages/workspace/[id]/edit.vue
+++ b/pages/workspace/[id]/edit.vue
@@ -14,8 +14,7 @@ const datatype = route.query.datatype
 const editor = route.query.editor
 const editorContainer = ref(null)
 
-//const oswManager = (editor === 'rapid3' && rapid3Manager) ? rapid3Manager : rapidManager
-const oswManager = rapid3Manager  // testing - force Rapid v3
+const oswManager = (editor === 'rapid3' && rapid3Manager) ? rapid3Manager : rapidManager
 const manager = datatype === 'osw' ? oswManager : pathwaysManager
 
 function onEditorLoaded() {

--- a/services/index.ts
+++ b/services/index.ts
@@ -11,6 +11,7 @@ import { OsmApiClient } from '~/services/osm';
 import { PathwaysEditorManager } from '~/services/pathways';
 import { ReviewManager } from '~/services/review';
 import { RapidManager } from '~/services/rapid';
+import { Rapid3Manager } from '~/services/rapid3';
 import { WorkspacesClient } from '~/services/workspaces';
 
 const tdeiApiUrl = import.meta.env.VITE_TDEI_API_URL;
@@ -20,6 +21,7 @@ const newApiUrl = import.meta.env.VITE_NEW_API_URL;
 const osmWebUrl = import.meta.env.VITE_OSM_URL;
 const osmApiUrl = osmWebUrl + 'api/0.6/';
 const rapidUrl = import.meta.env.VITE_RAPID_URL;
+const rapid3Url = import.meta.env.VITE_RAPID3_URL;
 const pathwaysUrl = import.meta.env.VITE_PATHWAYS_EDITOR_URL;
 
 export const tdeiAuth = reactive(new TdeiAuthStore());
@@ -50,4 +52,5 @@ export const reviewManager = new ReviewManager(
 );
 
 export const rapidManager = new RapidManager(rapidUrl, osmWebUrl, tdeiAuth);
+export const rapid3Manager = rapid3Url ? new Rapid3Manager(rapid3Url, osmWebUrl, tdeiAuth) : null;
 export const pathwaysManager = new PathwaysEditorManager(pathwaysUrl, osmWebUrl, tdeiAuth);

--- a/services/rapid3.ts
+++ b/services/rapid3.ts
@@ -1,0 +1,213 @@
+import { ref } from 'vue'
+import type { TdeiAuthStore } from '~/services/tdei'
+
+/** Global `Rapid` namespace injected by the Rapid v3.x script at runtime. */
+declare const Rapid: any
+
+/**
+ * Manages the lifecycle of an embedded Rapid v3.x editor instance.
+ *
+ * Handles loading the Rapid v3.x script and stylesheet into the DOM, initializing
+ * the editor context for a given workspace, switching between workspaces, and
+ * patching Rapid's network layer to inject TDEI auth and workspace headers.
+ *
+ * Instantiated conditionally in `services/index.ts` — only when the
+ * `VITE_RAPID3_URL` environment variable is set.
+ */
+export class Rapid3Manager {
+  #baseUrl: string
+  #osmUrl: string
+  #tdeiAuth: TdeiAuthStore
+
+  /** Reactive flag indicating whether the Rapid 3 script has loaded and is ready. */
+  loaded: ReturnType<typeof ref<boolean>>
+
+  /** The DOM element that the Rapid editor mounts into. */
+  containerNode: HTMLDivElement
+
+  /** The Rapid `Context` instance, available after loading completes. */
+  rapidContext: any
+
+
+  /**
+   * @constructor
+   * @param baseUrl - Base URL where Rapid static assets are served
+   *                  A trailing slash is enforced automatically.
+   * @param osmUrl  - Base URL of the OSM-compatible API backend.
+   * @param tdeiAuth - Reactive auth store providing access tokens and auth state.
+   */
+  constructor(baseUrl: string, osmUrl: string, tdeiAuth: TdeiAuthStore) {
+    this.#baseUrl = baseUrl.replace(/\/*$/, '/')
+    this.#osmUrl = osmUrl.replace(/\/+$/, '')
+    this.#tdeiAuth = tdeiAuth
+
+    this.loaded = ref(false)
+    this.containerNode = document.createElement('div')
+    this.rapidContext = null
+  }
+
+
+  /**
+   * Injects the Rapid v3.x JavaScript and CSS into the document.
+   *
+   * This is a one-time operation — subsequent calls are no-ops if the script
+   * has already been loaded. Once the script loads, {@link #onRapidLoaded} is
+   * called to prepare the Rapid context. If the script fails to load, an error
+   * is logged to the console.
+   */
+  load() {
+    if (this.loaded.value) {
+      return
+    }
+
+    const style = document.createElement('link')
+    style.setAttribute('href', this.#baseUrl + 'css/rapid.css')
+    style.setAttribute('type', 'text/css')
+    style.setAttribute('rel', 'stylesheet')
+    document.head.appendChild(style)
+
+    const script = document.createElement('script')
+    script.src = this.#baseUrl + 'js/rapid-dev.js'
+    script.async = true
+    script.onload = this.#onRapidLoaded.bind(this)
+    script.onerror = (e) => {
+      console.error('Failed to load Rapid3 script from:', script.src, e)
+    }
+    document.body.appendChild(script)
+  }
+
+
+  /**
+   * Script onload handler. Creates the Rapid `Context`, configures it for
+   * embedded mode, and runs `prepareAsync()`. Sets {@link loaded} to `true`
+   * once preparation is complete, signaling to the edit page that
+   * {@link init} can be called.
+   */
+  #onRapidLoaded() {
+    const container = this.containerNode;
+
+    if (typeof Rapid === 'undefined' || !Rapid.utilDetect().support) {
+      container.innerHTML = 'Sorry, your browser is not currently supported.'
+      container.style.padding = '20px'
+
+    } else {
+      const context = new Rapid.Context()
+      context.embed(true);   // hide the account management control
+      context.containerNode = container
+      context.assetPath = this.#baseUrl
+
+      this.rapidContext = context
+      context.prepareAsync()
+        .then(() => {
+          this.loaded.value = true
+        })
+    }
+  }
+
+
+  /**
+   * Initializes the Rapid editor for a specific workspace.
+   *
+   * Configures the workspace ID, TDEI auth, and OSM API connection, then runs
+   * Rapid's async init and start sequence. Must be called after {@link loaded}
+   * becomes `true`.
+   *
+   * @param workspaceId - The numeric ID of the workspace to open for editing.
+   * @returns A promise that resolves once the editor is fully started.
+   */
+  init(workspaceId: number) {
+    const context = this.rapidContext
+    context.workspaceId = workspaceId
+    context.tdeiAuth = this.#tdeiAuth
+    context.preauth = { url: this.#osmUrl, apiUrl: this.#osmUrl }
+
+    return context.initAsync()
+      .then(() => this.#patchRapid())
+      .then(() => context.startAsync())
+  }
+
+
+  /**
+   * Switches the editor to a different workspace without a full reload.
+   *
+   * Updates the workspace ID and dispatches a synthetic `hashchange` event to
+   * make Rapid re-read its configuration from the URL hash, then resets the
+   * editor state.
+   *
+   * @param workspaceId - The numeric ID of the workspace to switch to.
+   * @returns A promise that resolves once the editor has reset.
+   */
+  switchWorkspace(workspaceId: number) {
+    this.rapidContext.workspaceId = workspaceId
+
+    window.dispatchEvent(new HashChangeEvent('hashchange', {
+      newURL: window.location.href,
+      oldURL: window.location.href,
+    }))
+
+    return this.rapidContext.resetAsync()
+  }
+
+
+  /**
+   * Patches Rapid's OSM service layer to use TDEI authentication.
+   *
+   * Replaces the built-in OAuth fetch with {@link #wrapFetch} to inject
+   * workspace and authorization headers, overrides the `authenticated` check
+   * to use TDEI auth state, and stubs out `userDetails` (not needed for
+   * workspace-based changeset uploads).
+   */
+  #patchRapid() {
+    const context = this.rapidContext
+    const rapidOsmService = context.services.osm
+    const rapidOsmClient = rapidOsmService._oauth
+
+    rapidOsmClient.fetch = this.#wrapFetch(rapidOsmClient.fetch)
+    rapidOsmClient.authenticated = () => this.#tdeiAuth.ok
+
+    rapidOsmService.userDetails = (callback: (err: string) => void) => { callback('dummy error') }
+  }
+
+
+  /**
+   * Wraps a fetch function to inject `X-Workspace` and `Authorization` headers
+   * on every request Rapid makes to the OSM API.
+   *
+   * Handles all three header formats that Rapid/osm-auth may use: `Headers`
+   * instance, array of tuples, or plain object. When headers are a plain object,
+   * `Authorization` is defined as non-writable to prevent osm-auth from
+   * overwriting it with its own OAuth token.
+   *
+   * @param innerFetch - The original fetch function from Rapid's OAuth client.
+   * @returns A wrapped fetch function with workspace/auth headers injected.
+   */
+  #wrapFetch(innerFetch: typeof fetch) {
+    return (resource: RequestInfo | URL, options: RequestInit & { headers?: HeadersInit | Record<string, string> }) => {
+      if (!options.headers) {
+        options.headers = new Headers()
+      }
+
+      const tokenHeader = 'Bearer ' + this.#tdeiAuth.accessToken
+
+      if (options.headers instanceof Headers) {
+        options.headers.set('X-Workspace', this.rapidContext.workspaceId)
+        options.headers.set('Authorization', tokenHeader)
+      }
+      else if (Array.isArray(options.headers)) {
+        options.headers.push(['X-Workspace', this.rapidContext.workspaceId])
+        options.headers.push(['Authorization', tokenHeader])
+      }
+      else {
+        options.headers['X-Workspace'] = this.rapidContext.workspaceId
+
+        Object.defineProperty(options.headers, 'Authorization', {
+          value: tokenHeader,
+          writable: false,
+          enumerable: true,
+        })
+      }
+
+      return innerFetch(resource, options)
+    }
+  }
+}


### PR DESCRIPTION
This commit adds:
- adds `rapid3.ts`  Rapid3Manager for instantiating the new version of rapid
- changes the edit button to be a split button with dropdown options for picking different rapid versions
- updates the `.env.example` with the example urls for loading different versions from [workspaces-rapid](https://github.com/TaskarCenterAtUW/workspaces-rapid)
- side note: `index.ts` is showing up as having a lot of changes in it - I believe this was just from being converted from CRLF to LF newlines.  The only significant change was the addition of the Rapid3 manager at the end.
 
<img width="400" alt="Screenshot 2026-03-24 at 11 34 19 AM" src="https://github.com/user-attachments/assets/41dba1b5-418a-4813-84ec-b734a6ccb41d" />

The dropdown allows us to offer multiple editors from here.
If the user clicks the main part of the button, they just get the default Rapid 2.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds support for Rapid v3 alongside Rapid v2 by introducing a new Rapid3Manager and converting the Edit button into a split dropdown so users can choose "Rapid 2 (default)" or "Rapid 3 (beta)". Rapid 2 remains the default; Rapid 3 is offered conditionally only when a Rapid 3 URL is configured.

## Changes by File

### .env.example
- Added `VITE_RAPID3_URL` (example: `https://rapid.workspaces-dev.sidewalks.washington.edu/rapid3/`)
- Updated `VITE_RAPID_URL` to point to the Rapid v2 path (`.../rapid2/`)
- Pathways editor URL unchanged

### components/dashboard/Toolbar.vue
- Replaced the single Edit link with a split dropdown for OSW workspaces when `rapid3Manager` is present
  - Main split launches the default `editRoute` (Rapid 2)
  - Dropdown offers "Rapid 2 (default)" and "Rapid 3 (beta)" (navigates with `editor: 'rapid3'` query)
- Added computed helpers: `isOsw`, `rapid3Available` (guard), and `editRouteRapid3`
- Import/use of `rapid3Manager` to conditionally show Rapid 3 option

### pages/workspace/[id]/edit.vue
- Editor selection now considers `route.query.editor`
- Imports `rapid3Manager` and computes `oswManager` to choose between `rapidManager` (v2) and `rapid3Manager` (v3)
- On mount, if the other Rapid manager is already loaded, triggers a hard reload to swap editor versions; otherwise preserves existing load/switch behavior

### services/index.ts
- Added `rapid3Url` from `import.meta.env.VITE_RAPID3_URL`
- Exported `rapid3Manager` as `Rapid3Manager | null` — initialized only when `rapid3Url` is truthy
- Note: this file shows many line-ending changes (CRLF → LF); the substantive addition is exporting the Rapid3 manager at the end

### services/rapid3.ts (new)
- New `Rapid3Manager` class to manage embedded Rapid v3:
  - Normalizes base and OSM URLs, stores TDEI auth, exposes `loaded` and `containerNode`
  - `load()` injects Rapid v3 CSS/JS (idempotent with error handling)
  - `init(workspaceId)` runs Rapid’s prepare/init/start sequence and applies patches
  - `switchWorkspace(workspaceId)` updates context, dispatches synthetic `hashchange`, and calls `resetAsync()`
  - Internal patches wrap Rapid’s OAuth fetch to inject `X-Workspace` and `Authorization: Bearer <token>` headers, override authenticated checks to use TDEI auth, and stub userDetails
  - Handles unsupported-browser case with UI message

## Other notes
- Rapid 3 availability is guarded: the UI only offers the Rapid 3 dropdown option when `rapid3Manager` exists (i.e., when `VITE_RAPID3_URL` is configured).
- Screenshot in the PR shows the split Edit button and the mapping/canvas UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->