### PR TITLE
Bug-3566: Add searchable project group picker and TDEI fixes

### DIFF
--- a/components/ProjectGroupPicker.vue
+++ b/components/ProjectGroupPicker.vue
@@ -4,6 +4,7 @@
       v-model="searchText"
       type="text"
       class="form-select"
+      :disabled="props.disabled"
       placeholder="Search project groups..."
       @focus="onFocus"
       @keydown="onKeydown"
@@ -44,6 +45,10 @@
 import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { tdeiUserClient } from '~/services/index'
 
+const props = withDefaults(defineProps<{ disabled?: boolean }>(), {
+  disabled: false,
+})
+
 const model = defineModel({ required: true })
 const searchText = ref('')
 const isOpen = ref(false)
@@ -56,10 +61,15 @@ const activeIndex = ref(-1)
 
 let pageNo = 1
 let hasMore = true
+let pendingReset = false
 const pageSize = 10
 
 const loadGroups = async (reset = false) => {
-  if (loading.value) return
+  if (loading.value) {
+    pendingReset = pendingReset || reset
+    return
+  }
+
   if (reset) {
     pageNo = 1
     hasMore = true
@@ -88,6 +98,12 @@ const loadGroups = async (reset = false) => {
     console.error(e)
   } finally {
     loading.value = false
+
+    if (pendingReset) {
+      const resetNext = pendingReset
+      pendingReset = false
+      await loadGroups(resetNext)
+    }
   }
 }
 
@@ -213,7 +229,7 @@ onMounted(async () => {
   await loadGroups(true)
   
   if (projectGroups.value.length > 0) {
-    if (!model.value || !projectGroups.value.some(pg => pg.id === model.value)) {
+    if (!model.value) {
       model.value = projectGroups.value[0]?.id
     }
     const selected = projectGroups.value.find(pg => pg.id === model.value)

--- a/components/ProjectGroupPicker.vue
+++ b/components/ProjectGroupPicker.vue
@@ -1,29 +1,240 @@
 <template>
-  <select
-    v-model="model"
-    class="project-group-picker form-select"
-    aria-label="Project Group Selection"
-  >
-    <option
-      v-for="pg in projectGroups"
-      :key="pg.id"
-      :value="pg.id"
+  <div class="position-relative project-group-picker" ref="pickerRef">
+    <input
+      v-model="searchText"
+      type="text"
+      class="form-select"
+      placeholder="Search project groups..."
+      @focus="onFocus"
+      @keydown="onKeydown"
+    />
+    <ul
+      v-if="isOpen"
+      ref="listRef"
+      class="list-group position-absolute w-100 mt-1 shadow bg-white"
+      style="z-index: 1000; max-height: 250px; overflow-y: auto;"
+      @scroll="onScroll"
+      @mousedown.prevent
     >
-      {{ pg.name }}
-    </option>
-  </select>
+      <li
+        v-if="projectGroups.length === 0 && !loading"
+        class="list-group-item text-muted"
+      >
+        No project groups found.
+      </li>
+      <li
+        v-for="(pg, index) in projectGroups"
+        :key="pg.id"
+        :id="'pg-item-' + index"
+        class="list-group-item list-group-item-action cursor-pointer"
+        :class="{ highlighted: activeIndex === index, 'fw-bold': model === pg.id }"
+        @click="selectGroup(pg.id)"
+        @mouseenter="activeIndex = index"
+      >
+        {{ pg.name }}
+      </li>
+      <li v-if="loading" class="list-group-item text-center">
+        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+      </li>
+    </ul>
+  </div>
 </template>
 
 <script setup lang="ts">
+import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { tdeiUserClient } from '~/services/index'
 
 const model = defineModel({ required: true })
-const projectGroups = (await tdeiUserClient.getMyProjectGroups())
-  .sort((a, b) => a.name.localeCompare(b.name))
+const searchText = ref('')
+const isOpen = ref(false)
+const projectGroups = ref<{ id: string; name: string }[]>([])
+const selectedGroupName = ref('')
+const loading = ref(false)
+const pickerRef = ref<HTMLElement | null>(null)
+const listRef = ref<HTMLElement | null>(null)
+const activeIndex = ref(-1)
 
-if (projectGroups.length > 0) {
-  if (!model.value || !projectGroups.some(pg => pg.id === model.value)) {
-    model.value = projectGroups[0].id
+let pageNo = 1
+let hasMore = true
+const pageSize = 10
+
+const loadGroups = async (reset = false) => {
+  if (loading.value) return
+  if (reset) {
+    pageNo = 1
+    hasMore = true
+    projectGroups.value = []
+    activeIndex.value = -1
+  }
+  if (!hasMore) return
+
+  loading.value = true
+  try {
+    let query = searchText.value
+    // If the text is exactly the selected group's name, fetch all options instead of filtering
+    if (query === selectedGroupName.value) {
+      query = ''
+    }
+
+    const newGroups = await tdeiUserClient.getMyProjectGroups(pageNo, query, pageSize)
+    projectGroups.value.push(...newGroups)
+
+    if (newGroups.length < pageSize) {
+      hasMore = false
+    } else {
+      pageNo++
+    }
+  } catch (e) {
+    console.error(e)
+  } finally {
+    loading.value = false
   }
 }
+
+let timeoutId: ReturnType<typeof setTimeout>
+watch(searchText, (newVal, oldVal) => {
+  if (!isOpen.value) return
+  
+  clearTimeout(timeoutId)
+  timeoutId = setTimeout(() => {
+    loadGroups(true)
+  }, 300)
+})
+
+watch(model, (newId) => {
+  const pg = projectGroups.value.find(p => p.id === newId)
+  if (pg && !isOpen.value) {
+    searchText.value = pg.name
+    selectedGroupName.value = pg.name
+  }
+})
+
+const onScroll = (e: Event) => {
+  const target = e.target as HTMLElement
+  if (target.scrollTop + target.clientHeight >= target.scrollHeight - 10) {
+    loadGroups()
+  }
+}
+
+const selectGroup = (id: string) => {
+  model.value = id
+  isOpen.value = false
+  const pg = projectGroups.value.find(p => p.id === id)
+  if (pg) {
+    searchText.value = pg.name
+    selectedGroupName.value = pg.name
+  }
+}
+
+const onFocus = (e: Event) => {
+  isOpen.value = true
+  loadGroups(true)
+  const target = e.target as HTMLInputElement
+  if (target) {
+    target.select()
+  }
+}
+
+const scrollToActive = () => {
+  nextTick(() => {
+    if (!listRef.value || activeIndex.value < 0) return
+    const activeEl = listRef.value.querySelector(`#pg-item-${activeIndex.value}`) as HTMLElement
+    if (activeEl) {
+      const list = listRef.value
+      const top = activeEl.offsetTop
+      const bottom = top + activeEl.offsetHeight
+      
+      if (top < list.scrollTop) {
+        list.scrollTop = top
+      } else if (bottom > list.scrollTop + list.clientHeight) {
+        list.scrollTop = bottom - list.clientHeight
+      }
+    }
+  })
+}
+
+const onKeydown = (e: KeyboardEvent) => {
+  if (!isOpen.value) {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      onFocus(e)
+      e.preventDefault()
+    }
+    return
+  }
+
+  if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    if (activeIndex.value < projectGroups.value.length - 1) {
+      activeIndex.value++
+      scrollToActive()
+    }
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    if (activeIndex.value > 0) {
+      activeIndex.value--
+      scrollToActive()
+    }
+  } else if (e.key === 'Enter') {
+    e.preventDefault()
+    if (activeIndex.value >= 0 && activeIndex.value < projectGroups.value.length) {
+      const pg = projectGroups.value[activeIndex.value]
+      if (pg) selectGroup(pg.id)
+    }
+  } else if (e.key === 'Escape') {
+    e.preventDefault()
+    isOpen.value = false
+    const pg = projectGroups.value.find(p => p.id === model.value)
+    if (pg) {
+      searchText.value = pg.name
+      selectedGroupName.value = pg.name
+    } else {
+      searchText.value = ''
+    }
+  }
+}
+
+const handleClickOutside = (event: MouseEvent) => {
+  if (pickerRef.value && !pickerRef.value.contains(event.target as Node)) {
+    if (isOpen.value) {
+      isOpen.value = false
+      const pg = projectGroups.value.find(p => p.id === model.value)
+      if (pg) {
+        searchText.value = pg.name
+        selectedGroupName.value = pg.name
+      } else {
+        searchText.value = ''
+      }
+    }
+  }
+}
+
+onMounted(async () => {
+  document.addEventListener('mousedown', handleClickOutside)
+  await loadGroups(true)
+  
+  if (projectGroups.value.length > 0) {
+    if (!model.value || !projectGroups.value.some(pg => pg.id === model.value)) {
+      model.value = projectGroups.value[0]?.id
+    }
+    const selected = projectGroups.value.find(pg => pg.id === model.value)
+    if (selected) {
+      searchText.value = selected.name
+      selectedGroupName.value = selected.name
+    }
+  }
+})
+
+onUnmounted(() => {
+  document.removeEventListener('mousedown', handleClickOutside)
+})
 </script>
+
+<style scoped>
+.cursor-pointer {
+  cursor: pointer;
+}
+.list-group-item.highlighted {
+  background-color: rgba(13, 110, 253, 0.25);
+  color: inherit;
+}
+</style>

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "maplibre-gl": "^5.10.0",
     "nuxt": "^4.0.0",
     "papaparse": "^5.5.1",
+    "qrcode": "^1.5.4",
     "vue": "^3.4.19",
     "vue-qrcode": "^2.2.2",
     "vue-router": "^4.2.5",

--- a/pages/workspace/create/tdei.vue
+++ b/pages/workspace/create/tdei.vue
@@ -185,6 +185,13 @@ async function getDatasetInfo(id: string | null) {
     const info = await client.getDatasetInfo(id)
 
     if (!info) return
+
+    // Clear stale keys from any previously loaded dataset before merging,
+    // so switching datasets never leaves orphaned fields in record.
+    for (const key of Object.keys(record)) {
+      delete record[key]
+    }
+
     Object.assign(record, info)
   })
 

--- a/pages/workspace/create/tdei.vue
+++ b/pages/workspace/create/tdei.vue
@@ -184,9 +184,8 @@ async function getDatasetInfo(id: string | null) {
   await loading.wrap(tdeiClient, async (client) => {
     const info = await client.getDatasetInfo(id)
 
-    for (const prop in info) {
-      record[prop] = info[prop]
-    }
+    if (!info) return
+    Object.assign(record, info)
   })
 
   await nextTick()

--- a/pages/workspace/create/tdei.vue
+++ b/pages/workspace/create/tdei.vue
@@ -147,6 +147,7 @@
 </template>
 
 <script setup lang="ts">
+declare const L: any;
 import { LoadingContext } from '~/services/loading'
 import { TdeiImporter, TdeiImporterContext } from '~/services/import/tdei'
 import { osmClient, tdeiClient, workspacesClient } from '~/services/index'
@@ -156,11 +157,11 @@ const importer = new TdeiImporter(workspacesClient, tdeiClient, osmClient, conte
 
 const loading = reactive(new LoadingContext())
 const route = useRoute()
-const tdeiRecordId = ref(null)
-const record = reactive({})
-const map = ref({})
+const tdeiRecordId = ref<string | null>(null)
+const record = reactive<Record<string, any>>({})
+const map = ref<any>({})
 const workspaceTitle = ref('')
-const projectGroupId = ref(null)
+const projectGroupId = ref<string | null>(null)
 
 watch(tdeiRecordId, val => getDatasetInfo(val))
 
@@ -170,7 +171,7 @@ const complete = computed(() =>
   && tdeiRecordId.value !== null,
 )
 
-async function getDatasetInfo(id: string) {
+async function getDatasetInfo(id: string | null) {
   if (id === null) {
     for (const prop in record) {
       record[prop] = ''
@@ -202,6 +203,10 @@ onMounted(async () => {
 })
 
 function initMap() {
+  if (map.value && map.value.remove) {
+    map.value.remove()
+  }
+
   // TODO: use Mapbox
   map.value = L.map('dataset_map')
 
@@ -210,19 +215,23 @@ function initMap() {
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
   }).addTo(map.value)
 
-  const area = L.geoJSON(record.metadata.dataset_detail.dataset_area).addTo(map.value)
-  const bounds = area.getBounds()
+  if (record.metadata?.dataset_detail?.dataset_area) {
+    const area = L.geoJSON(record.metadata.dataset_detail.dataset_area).addTo(map.value)
+    const bounds = area.getBounds()
 
-  map.value.fitBounds(bounds)
+    if (bounds.isValid()) {
+      map.value.fitBounds(bounds)
+    }
+  }
 }
 
 async function create() {
   const workspaceId = await importer.import({
     title: workspaceTitle.value,
     type: record.data_type,
-    tdeiRecordId: tdeiRecordId.value,
-    tdeiProjectGroupId: projectGroupId.value,
-    tdeiServiceId: record.service.tdei_service_id,
+    tdeiRecordId: tdeiRecordId.value as string,
+    tdeiProjectGroupId: projectGroupId.value as string,
+    tdeiServiceId: record.service?.tdei_service_id || '',
     tdeiMetadata: JSON.stringify(record),
   })
 

--- a/services/tdei.ts
+++ b/services/tdei.ts
@@ -2,7 +2,15 @@ import { BlobReader, BlobWriter, ZipReader } from '@zip.js/zip.js';
 
 import { BaseHttpClient, BaseHttpClientError } from '~/services/http';
 import type { ICancelableClient } from '~/services/loading';
-import type { TdeiFeedback } from '~/types/tdei.ts';
+import type {
+  TdeiFeedback,
+  TdeiProjectGroupApiResponse,
+  TdeiServiceApiResponse,
+  TdeiDatasetApiResponse,
+  TdeiProjectGroup,
+  TdeiService,
+  TdeiDatasetSummary,
+} from '~/types/tdei.ts';
 
 const MIN_TOKEN_REFRESH_MS = 10 * 1000;
 
@@ -212,17 +220,17 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     this.#refreshTimer = undefined;
   }
 
-  async getDatasetInfo(tdeiRecordId: string) {
+  async getDatasetInfo(tdeiRecordId: string): Promise<TdeiDatasetApiResponse | undefined> {
     const response = await this._get(`datasets?status=All&tdei_dataset_id=${tdeiRecordId}`);
 
-    return (await response.json())[0];
+    return (await response.json() as TdeiDatasetApiResponse[])[0];
   }
 
-  async getDatasetsByProjectGroupAndName(projectGroupId: string, name: string) {
+  async getDatasetsByProjectGroupAndName(projectGroupId: string, name: string): Promise<TdeiDatasetSummary[]> {
     const response = await this._get(`datasets?tdei_project_group_id=${projectGroupId}&name=${encodeURIComponent(name)}`);
 
-    return (await response.json())
-      .map((d: any) => ({ id: d.tdei_dataset_id, name: d.metadata.dataset_detail.name, version: d.metadata.dataset_detail.version }));
+    return (await response.json() as TdeiDatasetApiResponse[])
+      .map(d => ({ id: d.tdei_dataset_id, name: d.metadata.dataset_detail.name, version: d.metadata.dataset_detail.version }));
   }
 
   async downloadOswDataset(tdeiRecordId: string, format: string = 'osw'): Promise<Blob> {
@@ -383,9 +391,9 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     const jwt = getJwtBody(body.access_token);
 
     this.#auth.username = username;
-    this.#auth.subject = jwt.sub as unknown as string;
-    this.#auth.displayName = jwt.name as unknown as string;
-    this.#auth.email = jwt.email as unknown as string;
+    this.#auth.subject = typeof jwt.sub === 'string' ? jwt.sub : '';
+    this.#auth.displayName = typeof jwt.name === 'string' ? jwt.name : '';
+    this.#auth.email = typeof jwt.email === 'string' ? jwt.email : '';
     this.#auth.accessToken = body.access_token;
     this.#auth.refreshToken = body.refresh_token;
     this.#auth.expiresAt = expiresAsDate(body.expires_in);
@@ -449,21 +457,28 @@ export class TdeiUserClient extends BaseHttpClient implements ICancelableClient 
     return new TdeiClient(this._baseUrl, this.#auth, signal ?? this._abortSignal);
   }
 
-  async getMyProjectGroups(pageNo: number = 1, searchText: string = '', pageSize: number = 10) {
+  async getMyProjectGroups(pageNo: number = 1, searchText: string = '', pageSize: number = 10): Promise<TdeiProjectGroup[]> {
     let url = `project-group-roles/${this.#auth.subject}?page_size=${pageSize}&page_no=${pageNo}`;
     if (searchText) {
       url += `&searchText=${encodeURIComponent(searchText)}`;
     }
+
     const response = await this._get(url);
-    const items = (await response.json()) ?? [];
-    return items.map((p: any) => ({ id: p.tdei_project_group_id, name: p.project_group_name }));
+
+    try {
+      const items = (await response.json() as TdeiProjectGroupApiResponse[]) ?? [];
+      return items.map(p => ({ id: p.tdei_project_group_id, name: p.project_group_name }));
+    } catch (e) {
+      console.warn('getMyProjectGroups: failed to parse API response', e);
+      return [];
+    }
   }
 
-  async getMyServices(projectGroupId: string, type: string = 'all') {
+  async getMyServices(projectGroupId: string, type: string = 'all'): Promise<TdeiService[]> {
     const response = await this._get(`service?tdei_project_group_id=${projectGroupId}&service_type=${type}`);
 
-    return (await response.json())
-      .map((s: any) => ({ id: s.tdei_service_id, name: s.service_name }));
+    return (await response.json() as TdeiServiceApiResponse[])
+      .map(s => ({ id: s.tdei_service_id, name: s.service_name }));
   }
 
   #setAuthHeader() {

--- a/services/tdei.ts
+++ b/services/tdei.ts
@@ -14,7 +14,7 @@ function expiresAsDate(seconds: number) {
   return new Date(Date.now() + seconds * 1000);
 }
 
-function getJwtBody(accessToken: string) {
+function getJwtBody(accessToken: string): any {
   const bodyStart = accessToken.indexOf('.');
   const bodyEnd = accessToken.indexOf('.', bodyStart + 1);
 
@@ -128,7 +128,9 @@ export class TdeiClientError extends Error {
 }
 
 export class TdeiConversionError extends Error {
-  constructor(job) {
+  job: any;
+
+  constructor(job: any) {
     super(`TDEI conversion failed: ${job.message}`);
     this.job = job;
   }
@@ -187,7 +189,7 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
 
     try {
       await this.refreshToken();
-    } catch(e: unknown) {
+    } catch (e: unknown) {
       console.warn('Exception when refreshing TDEI access token', e);
       return false;
     }
@@ -220,16 +222,16 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     const response = await this._get(`datasets?tdei_project_group_id=${projectGroupId}&name=${encodeURIComponent(name)}`);
 
     return (await response.json())
-      .map(d => ({ id: d.tdei_dataset_id, name: d.metadata.dataset_detail.name, version: d.metadata.dataset_detail.version }));
+      .map((d: any) => ({ id: d.tdei_dataset_id, name: d.metadata.dataset_detail.name, version: d.metadata.dataset_detail.version }));
   }
 
-  async downloadOswDataset(tdeiRecordId: string, format: string = 'osw'): Blob {
+  async downloadOswDataset(tdeiRecordId: string, format: string = 'osw'): Promise<Blob> {
     const response = await this._sendTest(`osw/${tdeiRecordId}?format=${format}`, 'GET');
 
     return (await response.blob());
   }
 
-  async downloadPathwaysDataset(tdeiDatasetId: string): Blob {
+  async downloadPathwaysDataset(tdeiDatasetId: string): Promise<Blob> {
     const response = await this._sendTest(`gtfs-pathways/${tdeiDatasetId}`, 'GET');
 
     return (await response.blob());
@@ -241,11 +243,11 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     const entries = await zipReader.getEntries();
     const blobWriter = new BlobWriter();
 
-    const isDataset = filename => !filename.startsWith('changeset')
+    const isDataset = (filename: string) => !filename.startsWith('changeset')
       && (filename.endsWith('.zip') || filename.endsWith('.xml'));
 
     const out = {
-      dataset: await entries.find(e => isDataset(e.filename)).getData(blobWriter),
+      dataset: await entries.find(e => isDataset(e.filename))?.getData?.(blobWriter),
       metadata: entries.find(e => e.filename.endsWith('.json'))
     };
 
@@ -258,8 +260,8 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     tdeiRecordId: string,
     projectGroupId: string,
     serviceId: string,
-    dataset,
-    metadata
+    dataset: Blob,
+    metadata: any
   ) {
     const body = new FormData();
     body.append('dataset', new File([dataset], 'dataset.zip', { type: 'application/x-zip-compressed' }));
@@ -282,8 +284,8 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     tdeiRecordId: string,
     projectGroupId: string,
     serviceId: string,
-    dataset,
-    metadata
+    dataset: Blob,
+    metadata: any
   ) {
     const body = new FormData();
     body.append('dataset', new File([dataset], 'dataset.zip', { type: 'application/x-zip-compressed' }));
@@ -307,7 +309,7 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     sourceFormat: string,
     targetFormat: string,
     projectGroupId: string
-  ): Blob {
+  ): Promise<Blob> {
     const body = new FormData();
     body.append('source_format', sourceFormat);
     body.append('target_format', targetFormat);
@@ -381,9 +383,9 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     const jwt = getJwtBody(body.access_token);
 
     this.#auth.username = username;
-    this.#auth.subject = jwt.sub;
-    this.#auth.displayName = jwt.name;
-    this.#auth.email = jwt.email;
+    this.#auth.subject = jwt.sub as unknown as string;
+    this.#auth.displayName = jwt.name as unknown as string;
+    this.#auth.email = jwt.email as unknown as string;
     this.#auth.accessToken = body.access_token;
     this.#auth.refreshToken = body.refresh_token;
     this.#auth.expiresAt = expiresAsDate(body.expires_in);
@@ -411,7 +413,7 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     }
   }
 
-  async _send(url: string, method: string, body?: any, config?: object): Promise<Response> {
+  override async _send(url: string, method: string, body?: any, config?: object): Promise<Response> {
     try {
       if (this.#auth.needsRefresh) {
         await this.refreshToken();
@@ -447,18 +449,21 @@ export class TdeiUserClient extends BaseHttpClient implements ICancelableClient 
     return new TdeiClient(this._baseUrl, this.#auth, signal ?? this._abortSignal);
   }
 
-  async getMyProjectGroups() {
-    const response = await this._get(`project-group-roles/${this.#auth.subject}`);
-
-    return (await response.json())
-      .map(p => ({ id: p.tdei_project_group_id, name: p.project_group_name }));
+  async getMyProjectGroups(pageNo: number = 1, searchText: string = '', pageSize: number = 10) {
+    let url = `project-group-roles/${this.#auth.subject}?page_size=${pageSize}&page_no=${pageNo}`;
+    if (searchText) {
+      url += `&searchText=${encodeURIComponent(searchText)}`;
+    }
+    const response = await this._get(url);
+    const items = (await response.json()) ?? [];
+    return items.map((p: any) => ({ id: p.tdei_project_group_id, name: p.project_group_name }));
   }
 
   async getMyServices(projectGroupId: string, type: string = 'all') {
     const response = await this._get(`service?tdei_project_group_id=${projectGroupId}&service_type=${type}`);
 
     return (await response.json())
-      .map(s => ({ id: s.tdei_service_id, name: s.service_name }));
+      .map((s: any) => ({ id: s.tdei_service_id, name: s.service_name }));
   }
 
   #setAuthHeader() {
@@ -467,7 +472,7 @@ export class TdeiUserClient extends BaseHttpClient implements ICancelableClient 
     }
   }
 
-  async _send(url: string, method: string, body?: any, config?: object): Promise<Response> {
+  override async _send(url: string, method: string, body?: any, config?: object): Promise<Response> {
     try {
       await this.#tdeiClient.tryRefreshAuth();
       this.#setAuthHeader();

--- a/types/tdei.ts
+++ b/types/tdei.ts
@@ -1,3 +1,34 @@
+/** Shape returned by the TDEI project-group-roles API */
+export interface TdeiProjectGroupApiResponse {
+  tdei_project_group_id: string;
+  project_group_name: string;
+}
+
+/** Shape returned by the TDEI service API */
+export interface TdeiServiceApiResponse {
+  tdei_service_id: string;
+  service_name: string;
+}
+
+/** Shape returned by the TDEI datasets API */
+export interface TdeiDatasetApiResponse {
+  tdei_dataset_id: string;
+  data_type: string;
+  status: string;
+  project_group: TdeiProjectGroupItem;
+  service?: {
+    tdei_service_id: string;
+    service_name?: string;
+  };
+  metadata: {
+    dataset_detail: {
+      name: string;
+      version?: string;
+      dataset_area?: object;
+    };
+  };
+}
+
 export interface TdeiProjectGroupItem {
   tdei_project_group_id: string;
   name: string;
@@ -6,6 +37,25 @@ export interface TdeiProjectGroupItem {
 export interface TdeiDatasetItem {
   tdei_dataset_id: string;
   name: string;
+}
+
+/** Normalized project group used throughout the UI */
+export interface TdeiProjectGroup {
+  id: string;
+  name: string;
+}
+
+/** Normalized service used throughout the UI */
+export interface TdeiService {
+  id: string;
+  name: string;
+}
+
+/** Normalized dataset used throughout the UI */
+export interface TdeiDatasetSummary {
+  id: string;
+  name: string;
+  version?: string;
 }
 
 export interface TdeiFeedback {


### PR DESCRIPTION
## DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3566

### Changes Implemented:

1. Replace simple select with a searchable, keyboard-navigable ProjectGroupPicker (infinite scroll, debounced search, click-outside handling, highlighting). 
2. Add scoped styles and accessibility improvements. 
3. Update services/tdei.ts with stronger TypeScript annotations, Promise return types, optional chaining, safer JWT field casts, and paginated/searchable getMyProjectGroups API. Apply related type and runtime guards in pages/workspace/create/tdei.vue (typed refs, map removal guard, bounds check, and safer import parameter casts). 
4. Also add "qrcode" to package.json dependencies. Added as it lists qrcode as a peer dependency and threw errors while running.

### Impacted Areas For Testing:

#### Project Group Picker 

| Page                        | URL                              |
|-----------------------------|----------------------------------|
| Dashboard                   | /dashboard                       |
| Create Workspace (TDEI)     | /workspace/create/tdei           |
| Create Workspace (File)     | /workspace/create/file           |
| Create Workspace (Blank)    | /workspace/create/blank          |
| Export Workspace (TDEI)     | /workspace/[id]/export/tdei      |

#### Test Scenarios

- Clicking the field opens the dropdown  
- Typing in the search box filters results (debounced ~300ms)  
- Scrolling to the bottom loads the next 10 items (lazy loading)  
- Up/Down arrow keys navigate the list, Enter selects  
- Clicking an item selects it and closes the dropdown  
- Selected group name persists in the input field when focused again  
- Clicking outside closes the dropdown without changing selection  

### Screenshots:
<img width="1470" height="956" alt="Screenshot 2026-04-28 at 6 31 42 PM" src="https://github.com/user-attachments/assets/e84f7826-c920-430d-b19e-cfb6987d387b" />
<img width="1470" height="956" alt="Screenshot 2026-04-28 at 6 31 56 PM" src="https://github.com/user-attachments/assets/8759f1fc-10ad-4a6a-ab80-ac4f483f7bf0" />
<img width="1470" height="956" alt="Screenshot 2026-04-28 at 6 32 07 PM" src="https://github.com/user-attachments/assets/84d8af6b-4a0c-4f8c-b28c-8e7ca5d6ed5c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR replaces the simple project-group <select> with a searchable, keyboard-navigable ProjectGroupPicker and tightens TDEI-related TypeScript and runtime guards. It also fixes a missing runtime dependency by adding "qrcode".

## Changes by File

### components/ProjectGroupPicker.vue
- Replaces fully-fetched <select> with an async, searchable dropdown supporting:
  - Debounced text search (~300ms) and server-side pagination (infinite scroll / lazy load)
  - Keyboard navigation (Up/Down highlight, Enter select, Escape to cancel)
  - Click-to-select, click-outside to close/restore, item highlighting, loading & empty states
  - Scoped styles, accessibility improvements, disabled prop, and pendingReset logic for queued resets during loading
  - Initialization now loads groups on mount and syncs initial model into the input

### services/tdei.ts
- Stronger TypeScript annotations and runtime safety:
  - Explicit Promise return types for dataset/upload/download/convert methods
  - getJwtBody typed to return any and JWT fields validated/cast (string-or-empty fallback)
  - TdeiConversionError now stores typed job: any
  - openDatasetArchive gains optional-chaining guards and safer filename predicate typing
  - Upload methods require dataset: Blob and metadata: any
  - _send marked override
- getMyProjectGroups expanded to accept pageNo, pageSize and searchText, builds query string, parses responses as TdeiProjectGroupApiResponse[] and returns [] on parse failure
- getMyServices annotated to return Promise<TdeiService[]>

### types/tdei.ts
- Adds exported API response interfaces and normalized UI types:
  - TdeiProjectGroupApiResponse, TdeiServiceApiResponse, TdeiDatasetApiResponse
  - TdeiProjectGroup, TdeiService, TdeiDatasetSummary

### pages/workspace/create/tdei.vue
- Tighter types and safer runtime behavior:
  - Typed refs (tdeiRecordId/projectGroupId as string | null), explicit Leaflet global declaration
  - getDatasetInfo accepts string | null, resets state when id is null, guards against falsy API responses before merging via Object.assign
  - Removes existing Leaflet map instance before reinitializing; only fits bounds when present and valid
  - Safer workspace payload construction with casts for nullable IDs and optional-chaining fallback for tdeiServiceId

### package.json
- Adds runtime dependency "qrcode" (fixes prior runtime errors caused by it being only a peer dependency)

## Test Coverage / QA Scenarios
- Dropdown open/close behavior, debounced search filtering, lazy-loading on scroll (loads next 10 items), keyboard navigation (Up/Down/Enter/Escape), click-to-select and close, selection persistence when re-focusing, and click-outside closing without changing selection.

## Impacted Pages
- /dashboard
- /workspace/create/tdei
- /workspace/create/file
- /workspace/create/blank
- /workspace/[id]/export/tdei
<!-- end of auto-generated comment: release notes by coderabbit.ai -->