### PR TITLE
Fix missed call site from project group refactor

### DIFF
--- a/pages/workspace/[id]/export/tdei.vue
+++ b/pages/workspace/[id]/export/tdei.vue
@@ -123,9 +123,9 @@ const exporter = new TdeiExporter(tdeiClient, osmClient, context);
 const route = useRoute();
 const workspaceId = Number(route.params.id);
 
-const [workspace, myProjectGroups] = await Promise.all([
+const [workspace, { items: myProjectGroups }] = await Promise.all([
   workspacesClient.getWorkspace(workspaceId),
-  tdeiUserClient.getMyProjectGroups(),
+  tdeiUserClient.getMyProjectGroups(1, '', 10000),
 ]);
 
 const dataGeneratorRole = `${workspace.type}_data_generator`;


### PR DESCRIPTION
This fixes a missed call of `getMyProjectGroups()` in #44 following rebase of #50 which changed the behavior of the method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a missed update in the TDEI workspace export page's data loading logic that was introduced during the project group refactor from PR `#50` and issue `#44`.

### Changes

**pages/workspace/[id]/export/tdei.vue**

Updated the `Promise.all` call that fetches initial data to properly handle the API response structure:

- Modified the `getMyProjectGroups()` call to include explicit pagination parameters: `getMyProjectGroups(1, '', 10000)`
- Updated the destructuring pattern to extract the `items` property from the response object: `{ items: myProjectGroups }` instead of receiving the list directly

This aligns with the API contract where `getMyProjectGroups()` returns an object with structure `{ items: TdeiProjectGroup[], total?: number }` rather than directly returning an array. The fix ensures that `eligibleProjectGroups` is computed correctly from the proper array of project groups, maintaining the role-based export permission checks and default project-group selection logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TaskarCenterAtUW/workspaces-frontend/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->