### PR TITLE
Bug-3672: ProjectGroupPicker on select issue for non dashboard

### DIFF
--- a/components/ProjectGroupPicker.vue
+++ b/components/ProjectGroupPicker.vue
@@ -2,6 +2,7 @@
   <div class="position-relative project-group-picker" ref="pickerRef" @focusout="onFocusOut">
     <input
       v-model="searchText"
+      :id="props.id"
       type="text"
       class="form-select"
       :disabled="props.disabled"
@@ -88,7 +89,7 @@ import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { tdeiUserClient } from '~/services/index'
 import type { TdeiProjectGroupItem } from '~/types/tdei'
 
-const props = withDefaults(defineProps<{ disabled?: boolean; options?: TdeiProjectGroupItem[] }>(), {
+const props = withDefaults(defineProps<{ id?: string; disabled?: boolean; options?: TdeiProjectGroupItem[] }>(), {
   disabled: false,
 })
 

--- a/components/ProjectGroupPicker.vue
+++ b/components/ProjectGroupPicker.vue
@@ -23,7 +23,7 @@
             Showing first {{ projectGroups.length }} of {{ totalCount }} project groups
             <span v-if="hasMore && !loading" class="pg-scroll-hint">&#183; Scroll to continue loading</span>
           </template>
-          <template v-else-if="!hasMore">Showing all {{ projectGroups.length }} project group{{ projectGroups.length !== 1 ? 's' : '' }}</template>
+          <template v-else-if="!showScrollHint">Showing all {{ projectGroups.length }} project group{{ projectGroups.length !== 1 ? 's' : '' }}</template>
           <template v-else>
             Showing first {{ projectGroups.length }} results
             <span v-if="!loading" class="pg-scroll-hint">&#183; Scroll to continue loading</span>
@@ -33,7 +33,7 @@
       </div>
       <div
         class="pg-list-wrap"
-        :class="{ 'pg-has-more': hasMore && !loading }"
+        :class="{ 'pg-has-more': showScrollHint && !loading }"
         ref="listRef"
         @scroll="onScroll"
       >
@@ -89,8 +89,9 @@ import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { tdeiUserClient } from '~/services/index'
 import type { TdeiProjectGroupItem } from '~/types/tdei'
 
-const props = withDefaults(defineProps<{ id?: string; disabled?: boolean; options?: TdeiProjectGroupItem[] }>(), {
+const props = withDefaults(defineProps<{ id?: string; disabled?: boolean; options?: TdeiProjectGroupItem[]; rememberSelection?: boolean }>(), {
   disabled: false,
+  rememberSelection: false,
 })
 
 const model = defineModel({ required: true })
@@ -105,6 +106,7 @@ const listRef = ref<HTMLElement | null>(null)
 const activeIndex = ref(-1)
 
 const projectGroups = computed(() => props.options ?? fetchedGroups.value)
+const showScrollHint = computed(() => !props.options && hasMore.value)
 
 let pageNo = 1
 const hasMore = ref(true)
@@ -144,7 +146,9 @@ const loadGroups = async (reset = false) => {
     if (total !== undefined) totalCount.value = total
     fetchedGroups.value.push(...newGroups)
     const selected = newGroups.find(g => g.tdei_project_group_id === model.value)
-    if (selected) persistCachedName(selected.tdei_project_group_id, selected.name)
+    if (selected && props.rememberSelection) {
+      persistCachedName(selected.tdei_project_group_id, selected.name)
+    }
 
     if (newGroups.length < pageSize) {
       hasMore.value = false
@@ -205,7 +209,9 @@ const selectGroup = (id: string) => {
   if (pg) {
     searchText.value = pg.name
     selectedGroupName.value = pg.name
-    persistCachedName(pg.tdei_project_group_id, pg.name)
+    if (props.rememberSelection) {
+      persistCachedName(pg.tdei_project_group_id, pg.name)
+    }
   }
 }
 
@@ -296,7 +302,7 @@ watch(
   (groups) => {
     if (groups.length > 0) {
       const pgId = model.value as string | undefined
-      if (!pgId || !groups.some(pg => pg.tdei_project_group_id === pgId)) {
+      if (!pgId || (props.options && !groups.some(pg => pg.tdei_project_group_id === pgId))) {
         model.value = groups[0]?.tdei_project_group_id
       }
       const selected = groups.find(pg => pg.tdei_project_group_id === model.value)
@@ -311,7 +317,7 @@ watch(
 
 onMounted(async () => {
   // Show cached name immediately before the API call completes
-  if (model.value && loadCachedName(model.value as string)) {
+  if (props.rememberSelection && model.value && loadCachedName(model.value as string)) {
     applyCachedName()
   }
 
@@ -323,7 +329,7 @@ onMounted(async () => {
       if (selected) {
         searchText.value = selected.name
         selectedGroupName.value = selected.name
-      } else if (model.value && loadCachedName(model.value as string)) {
+      } else if (props.rememberSelection && model.value && loadCachedName(model.value as string)) {
         // Group is beyond page 1 — use the cached name for display
         applyCachedName()
       } else if (model.value) {

--- a/components/ServicePicker.vue
+++ b/components/ServicePicker.vue
@@ -37,10 +37,11 @@ async function refreshServices() {
   services.value = (await tdeiUserClient.getMyServices(props.projectGroupId, props.serviceType))
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  if (!model.value && services.length > 0) {
-    model.value = services[0].id
+  const selectedServiceStillExists = services.value.some(s => s.id === model.value)
+
+  if (!selectedServiceStillExists) {
+    model.value = services.value[0]?.id ?? null
   }
 }
 
 </script>
-

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -4,7 +4,10 @@
         <h2 class="visually-hidden">My Workspaces</h2>
 
         <label for="ws_project_group_picker">Project Group</label>
-        <project-group-picker v-model="currentProjectGroup" id="ws_project_group_picker" />
+        <project-group-picker
+          id="ws_project_group_picker"
+          v-model="currentProjectGroup"
+        />
 
         <nuxt-link class="btn btn-primary flex-shrink-0" to="/workspace/create">
           <app-icon variant="add" size="24" />

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -7,6 +7,7 @@
         <project-group-picker
           id="ws_project_group_picker"
           v-model="currentProjectGroup"
+          remember-selection
         />
 
         <nuxt-link class="btn btn-primary flex-shrink-0" to="/workspace/create">

--- a/pages/workspace/[id]/export/tdei.vue
+++ b/pages/workspace/[id]/export/tdei.vue
@@ -62,13 +62,16 @@
               Dataset Name
               <input v-model.trim="datasetName" class="form-control" />
             </label>
-            <label class="d-block mt-3">
-              Project Group
+            <div class="mt-3">
+              <label class="d-block" for="export_tdei_project_group">
+                Project Group
+              </label>
               <project-group-picker
+                id="export_tdei_project_group"
                 v-model="workspace.tdeiProjectGroupId"
                 :options="eligibleProjectGroups"
               />
-            </label>
+            </div>
             <label class="d-block mt-3">
               Service
               <service-picker

--- a/pages/workspace/[id]/export/tdei.vue
+++ b/pages/workspace/[id]/export/tdei.vue
@@ -75,6 +75,7 @@
             <label class="d-block mt-3">
               Service
               <service-picker
+                :key="workspace.tdeiProjectGroupId"
                 v-model="workspace.tdeiServiceId"
                 :project-group-id="workspace.tdeiProjectGroupId"
                 :service-type="workspace.type"
@@ -126,10 +127,12 @@ const exporter = new TdeiExporter(tdeiClient, osmClient, context);
 const route = useRoute();
 const workspaceId = Number(route.params.id);
 
-const [workspace, { items: myProjectGroups }] = await Promise.all([
+const [workspaceData, { items: myProjectGroups }] = await Promise.all([
   workspacesClient.getWorkspace(workspaceId),
   tdeiUserClient.getMyProjectGroups(1, '', 10000),
 ]);
+
+const workspace = reactive(workspaceData);
 
 const dataGeneratorRole = `${workspace.type}_data_generator`;
 const eligibleProjectGroups = myProjectGroups.filter(pg =>

--- a/pages/workspace/[id]/export/tdei.vue
+++ b/pages/workspace/[id]/export/tdei.vue
@@ -75,7 +75,6 @@
             <label class="d-block mt-3">
               Service
               <service-picker
-                :key="workspace.tdeiProjectGroupId"
                 v-model="workspace.tdeiServiceId"
                 :project-group-id="workspace.tdeiProjectGroupId"
                 :service-type="workspace.type"

--- a/pages/workspace/create/blank.vue
+++ b/pages/workspace/create/blank.vue
@@ -11,10 +11,15 @@
               <input v-model.trim="workspaceTitle" class="form-control" />
             </label>
 
-            <label class="d-block mb-3">
-              Project Group
-              <project-group-picker v-model="projectGroupId" />
-            </label>
+            <div class="mb-3">
+              <label class="d-block" for="create_blank_project_group">
+                Project Group
+              </label>
+              <project-group-picker
+                id="create_blank_project_group"
+                v-model="projectGroupId"
+              />
+            </div>
 
             <div>Dataset Type</div>
             <dataset-type-radio v-model="datasetType" class="mb-3" />

--- a/pages/workspace/create/file.vue
+++ b/pages/workspace/create/file.vue
@@ -16,14 +16,17 @@
               >
             </label>
 
-            <label class="d-block mb-3">
-              Project Group
+            <div class="mb-3">
+              <label class="d-block" for="create_file_project_group">
+                Project Group
+              </label>
               <project-group-picker
+                id="create_file_project_group"
                 v-model="projectGroupId"
                 :disabled="context.active"
                 required
               />
-            </label>
+            </div>
 
             <div>Dataset Type</div>
             <dataset-type-radio
@@ -109,4 +112,3 @@ async function create() {
   }
 }
 </script>
-

--- a/pages/workspace/create/tdei.vue
+++ b/pages/workspace/create/tdei.vue
@@ -20,14 +20,17 @@
               >
             </label>
 
-            <label class="d-block mb-3">
-              Project Group
+            <div class="mb-3">
+              <label class="d-block" for="create_tdei_project_group">
+                Project Group
+              </label>
               <project-group-picker
+                id="create_tdei_project_group"
                 v-model="projectGroupId"
                 :disabled="context.active"
                 required
               />
-            </label>
+            </div>
 
             <label v-if="!$route.query.tdeiRecordId" class="d-block mb-3">
               Dataset


### PR DESCRIPTION
## Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3672/

### Root Cause

On non-dashboard pages such as **Create Workspace**, the `ProjectGroupPicker` component was wrapped inside a `<label>` element.

When a user clicked a project group option:

1. The picker correctly executed its selection logic and closed the dropdown.
2. Because the picker lived inside a `<label>`, the browser immediately redirected focus back to the associated input.
3. That focus event triggered the picker’s open logic again.

Additional issues were also identified while fixing this flow:

1. `ProjectGroupPicker` was persisting project group selection globally via session storage, even on non-dashboard pages.
2. The picker could temporarily reset the dashboard selection to the first loaded project group while paginated results were still loading.
3. On **Export Workspace to the TDEI**, the picker showed the infinite-scroll hint even when a complete `options` list was already supplied.
4. On **Export Workspace to the TDEI**, the `ServicePicker` was not reliably updating after project group selection because:
   - the export page was using a plain `workspace` object instead of reactive form state
   - the service picker did not reconcile stale selected service ids after reloading services for a new project group

## Changes Implemented

#### 1. Added explicit input id support to `ProjectGroupPicker`

Updated the component so an `id` prop can be passed through to the internal `<input>`.

##### Changes
- Added `id?: string` to component props
- Bound `:id="props.id"` on the internal input

#### 2. Replaced nested label usage with explicit label association

Refactored pages that wrapped `ProjectGroupPicker` inside `<label>`.

### Files Updated
- `pages/workspace/create/blank.vue`
- `pages/workspace/create/file.vue`
- `pages/workspace/create/tdei.vue`
- `pages/workspace/[id]/export/tdei.vue`

#### 3. Scoped project group persistence to Dashboard only

Updated `ProjectGroupPicker` so remembered selection is opt-in instead of always enabled.

##### Changes
- Added `rememberSelection?: boolean` to `ProjectGroupPicker`
- Enabled `remember-selection` only on `pages/dashboard.vue`
- Prevented create/export pages from reading or writing the dashboard’s remembered project group

#### 4. Fixed dashboard project group reset during initial load

Adjusted picker fallback behavior so a valid existing selection is not replaced just because it is not present in the first fetched page of results.

#### 5. Corrected header text for static `options` mode

Updated the picker header logic for cases where a full project group list is passed in directly.

#### 6. Fixed service picker refresh on Export to TDEI

Updated the export flow so service selection stays in sync with the selected project group.

##### Changes
- Made export-page `workspace` state reactive in `pages/workspace/[id]/export/tdei.vue`
- Added `:key="workspace.tdeiProjectGroupId"` to `ServicePicker` on the export page so the component fully refreshes when project group changes
- Updated `components/ServicePicker.vue` so stale `tdeiServiceId` values are replaced when they do not exist in the refreshed service list
- If no services exist for the selected project group, the service selection is cleared

### Additional Files Updated
- `components/ProjectGroupPicker.vue`
- `components/ServicePicker.vue`
- `pages/dashboard.vue`

### Test Cases Covered

1. **Functional Behavior**

- Selecting a project group on Create Blank Workspace closes the dropdown immediately.
- Selecting a project group on Create Workspace from File closes the dropdown immediately.
- Selecting a project group on Create Workspace from TDEI closes the dropdown immediately.
- Selecting a project group on Export to TDEI closes the dropdown immediately.
- Selecting a project group on the Dashboard continues to work as before.
- On Export to TDEI, changing project group refreshes the Service picker options.
- On Export to TDEI, if the previously selected service is not valid for the new project group, the picker selects the first valid service.
- On Export to TDEI, if the new project group has no services, the service selection is cleared.
- On Export to TDEI, the picker header shows “Showing all N project groups” when a full list is supplied.

2. **Regression Coverage**

- The selected project group value still updates through `v-model`.
- The displayed project group name still populates in the input after selection.
- Keyboard and focus-driven open behavior in `ProjectGroupPicker` remains unchanged.
- Dataset loading behavior is unaffected because the `projectGroupId` binding and downstream watchers were not changed.
- Dashboard continues to remember its own selected project group.
- Non-dashboard pages no longer overwrite or reuse the remembered dashboard project group.
- Dashboard no longer temporarily resets to the first project group during initial paginated load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

### ProjectGroupPicker Component
- Added optional `id` prop to support explicit label association via `for="id"` binding.
- Introduced `rememberSelection` prop (default: false) to make session-storage persistence opt-in.
- Bound `:id="props.id"` on the internal input wrapper.
- Added `showScrollHint` computed and updated dropdown rendering/styling to use it.
- Made selection persistence (initial load and on selection) conditional on `rememberSelection`.
- Adjusted initial display and fallback logic in `onMounted` and the `projectGroups` watcher to respect `rememberSelection`.
- Corrected header text behavior when a full static options list is supplied (shows “Showing all N project groups”).
- Prop signature updated: defineProps<{ id?: string; disabled?: boolean; options?: TdeiProjectGroupItem[]; rememberSelection?: boolean }>().

### ServicePicker Component
- `refreshServices()` now verifies the currently selected `model` still exists in the newly loaded `services`.
- If the selected service is missing, the component sets `model` to the first available service id or `null` when none exist (avoids stale selections).
- This replaces the prior behavior that only initialized `model` when falsy.

### Dashboard Page
- Enabled selection persistence for the dashboard by passing `remember-selection` to `project-group-picker`.
- Fixed dashboard selection reset during initial paginated load by adjusting picker fallback behavior.
- Reformatted the component invocation for readability.

### Workspace Creation Pages (blank.vue, file.vue, tdei.vue)
- Replaced nested-label usage with explicit label-for-id associations to prevent labels returning focus to the picker's input.
- Each page now uses a dedicated container (`<div class="mb-3">`) with:
  - `<label for="...">`
  - `project-group-picker` with corresponding `id` prop
  - Removed direct label wrapping of the picker.

### TDEI Export Page (pages/workspace/[id]/export/tdei.vue)
- Restructured template to use an explicit `<label for="export_tdei_project_group">` and `project-group-picker id="export_tdei_project_group"`, removing the previous nested-label pattern.
- Wrapped fetched workspace result in a reactive `workspace` object (via `reactive(...)`) so export-page workspace state is reactive.
- Reconciled export flow to ensure ServicePicker refreshes correctly after project group changes: avoid unnecessary remounts (commit removes a previous `:key="workspace.tdeiProjectGroupId"`), preserve picker internal state, reconcile stale selected service ids, and clear selection when no services exist.

## Files touched
- components/ProjectGroupPicker.vue
- components/ServicePicker.vue
- pages/dashboard.vue
- pages/workspace/create/blank.vue
- pages/workspace/create/file.vue
- pages/workspace/create/tdei.vue
- pages/workspace/[id]/export/tdei.vue

## Impact
- Fixes the bug where ProjectGroupPicker reopened immediately after selection on non-dashboard pages by making persistence opt-in and removing nested label focus behavior.
- Ensures dashboard-only persistence scope.
- Prevents stale service selections and unnecessary remounts in the export flow.
- Improves accessibility and corrects header text for static option lists.

## Tests / Coverage
- Manual/test cases noted: immediate close behavior on create/export pages, dashboard persistence scoping, ServicePicker refresh and fallback, header text for static options, and regressions for v-model, input display, and keyboard/focus behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TaskarCenterAtUW/workspaces-frontend/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->