### PR TITLE
Cleanup HTTP client headers and testing code

### DIFF
--- a/services/http.ts
+++ b/services/http.ts
@@ -1,3 +1,9 @@
+export type FetchConfig = Omit<RequestInit, 'headers'> & {
+  headers?: Record<string, string>;
+};
+
+export type HttpBody = BodyInit | object;
+
 export class BaseHttpClientError extends Error {
   response: Response;
 
@@ -25,27 +31,27 @@ export abstract class BaseHttpClient {
     return this._baseUrl + rest
   }
 
-  _get(url: string, config?: object): Promise<Response> {
+  _get(url: string, config?: FetchConfig): Promise<Response> {
     return this._send(url, 'GET', undefined, config);
   }
 
-  _post(url: string, body?: any, config?: object): Promise<Response> {
+  _post(url: string, body?: HttpBody, config?: FetchConfig): Promise<Response> {
     return this._send(url, 'POST', body, config);
   }
 
-  _put(url: string, body?: any, config?: object): Promise<Response> {
+  _put(url: string, body?: HttpBody, config?: FetchConfig): Promise<Response> {
     return this._send(url, 'PUT', body, config);
   }
 
-  _patch(url: string, body?: any, config?: object): Promise<Response> {
+  _patch(url: string, body?: HttpBody, config?: FetchConfig): Promise<Response> {
     return this._send(url, 'PATCH', body, config);
   }
 
-  _delete(url: string, config?: object): Promise<Response> {
+  _delete(url: string, config?: FetchConfig): Promise<Response> {
     return this._send(url, 'DELETE', undefined, config);
   }
 
-  async _sendTest(url: string, method: string, body?: any): Promise<Response> {
+  async _sendTest(url: string, method: string, body?: HttpBody): Promise<Response> {
     const response = await fetch(this.url(url), {
       method,
       body,
@@ -62,21 +68,45 @@ export abstract class BaseHttpClient {
     return response;
   }
 
-  async _send(url: string, method: string, body?: any, config?: object): Promise<Response> {
+  async _send(
+    url: string,
+    method: string,
+    body?: HttpBody,
+    config?: FetchConfig,
+  ): Promise<Response> {
+    const { headers: configHeaders, ...restConfig } = config ?? {};
+    const mergedHeaders: Record<string, string> = {
+      ...this._requestHeaders,
+      ...configHeaders,
+    };
     const requestOptions = {
       method,
-      body,
-      headers: this._requestHeaders,
+      body: undefined as BodyInit | undefined,
+      headers: mergedHeaders,
       signal: this._abortSignal,
-      ...config
+      ...restConfig,
     };
 
-    if (requestOptions.headers['Content-Type'] === 'application/json'
-      && !(body instanceof FormData)
-      && typeof body !== 'undefined'
-      && body !== null
-    ) {
+    // Let the browser set Content-Type (and multipart boundary) for FormData:
+    if (body instanceof FormData) {
+      delete mergedHeaders['Content-Type'];
+      requestOptions.body = body;
+    }
+    else if (body !== null && body !== undefined && (
+      mergedHeaders['Content-Type'] === 'application/json'
+      || (
+        typeof body === 'object'
+        && !(body instanceof Blob)
+        && !(body instanceof ArrayBuffer)
+        && !ArrayBuffer.isView(body)
+        && !(body instanceof URLSearchParams)
+        && !(body instanceof ReadableStream)
+      )
+    )) {
       requestOptions.body = JSON.stringify(body);
+    }
+    else {
+      requestOptions.body = body as BodyInit;
     }
 
     const response = await fetch(this.url(url), requestOptions);

--- a/services/http.ts
+++ b/services/http.ts
@@ -51,23 +51,6 @@ export abstract class BaseHttpClient {
     return this._send(url, 'DELETE', undefined, config);
   }
 
-  async _sendTest(url: string, method: string, body?: HttpBody): Promise<Response> {
-    const response = await fetch(this.url(url), {
-      method,
-      body,
-      headers: {
-        'Accept': 'application/text',
-        'Authorization': this._requestHeaders.Authorization
-      }
-    });
-
-    if (!response.ok) {
-      throw new BaseHttpClientError(response);
-    }
-
-    return response;
-  }
-
   async _send(
     url: string,
     method: string,

--- a/services/osm.ts
+++ b/services/osm.ts
@@ -1,7 +1,12 @@
 import parseOsmChangeXml from '@osmcha/osmchange-parser';
 import type { FeatureCollection, Point } from 'geojson';
 
-import { BaseHttpClient, BaseHttpClientError } from "~/services/http";
+import {
+  BaseHttpClient,
+  BaseHttpClientError,
+  type FetchConfig,
+  type HttpBody,
+} from '~/services/http';
 import * as xml from '~/util/xml';
 
 import type { ICancelableClient } from '~/services/loading';
@@ -14,7 +19,6 @@ import type {
   OsmElement,
   OsmNode,
   OsmNote,
-  OsmTags,
   OsmWay,
 } from '~/types/osm';
 import type { WorkspaceId } from '~/types/workspaces';
@@ -207,7 +211,9 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
     this.#webUrl = webUrl;
     this.#tdeiClient = tdeiClient;
     this.#setAuthHeader();
-    this._requestHeaders['Accept'] = 'text/plain';
+
+    // OSM API can return XML or JSON based on the header or file extension:
+    this._requestHeaders['Accept'] = '*/*';
     this._requestHeaders['Content-Type'] = 'text/plain';
   }
 
@@ -234,8 +240,8 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
       display_name: this.auth.displayName
     };
 
-    await this._put(`user/${this.auth.subject}`, JSON.stringify(body), {
-      headers: { ...this._requestHeaders, 'Content-Type': 'application/json' }
+    await this._put(`user/${this.auth.subject}`, body, {
+      headers: { 'Content-Type': 'application/json' }
     });
   }
 
@@ -286,7 +292,6 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
   ): Promise<OsmElement> {
     const response = await this._get(`${type}/${id}/${version}`, {
       headers: {
-        ...this._requestHeaders,
         'Accept': 'application/json',
         'X-Workspace': workspaceId,
       },
@@ -301,7 +306,6 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
   async getNodes(workspaceId: WorkspaceId, nodeIds: (number | string)[]): Promise<OsmNode[]> {
     const response = await this._get(`nodes?nodes=${nodeIds.join(',')}`, {
       headers: {
-        ...this._requestHeaders,
         'Accept': 'application/json',
         'X-Workspace': workspaceId,
       },
@@ -319,7 +323,6 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
   async getWays(workspaceId: WorkspaceId, wayIds: (number | string)[]): Promise<OsmWay[]> {
     const response = await this._get(`ways?ways=${wayIds.join(',')}`, {
       headers: {
-        ...this._requestHeaders,
         'Accept': 'application/json',
         'X-Workspace': workspaceId,
       },
@@ -337,7 +340,6 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
   async getWaysForNode(workspaceId: WorkspaceId, nodeId: number): Promise<OsmElement[]> {
     const response = await this._get(`node/${nodeId}/ways`, {
       headers: {
-        ...this._requestHeaders,
         'Accept': 'application/json',
         'X-Workspace': workspaceId,
       },
@@ -348,7 +350,7 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
 
   async listChangesets(workspaceId: WorkspaceId): Promise<OsmChangeset[]> {
     const response = await this._get(`changesets.json`, {
-      headers: { ...this._requestHeaders, 'X-Workspace': workspaceId },
+      headers: { 'X-Workspace': workspaceId },
     });
 
     const changesets = (await response.json())?.changesets ?? [];
@@ -374,7 +376,6 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
 
     const response = await this._get(url, {
       headers: {
-        ...this._requestHeaders,
         'Accept': 'application/json',
         'X-Workspace': workspaceId,
       },
@@ -401,7 +402,6 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
   {
     const response = await this._get(`changeset/${changesetId}/download`, {
       headers: {
-        ...this._requestHeaders,
         'Accept': 'application/xml',
         'X-Workspace': workspaceId,
       },
@@ -427,7 +427,7 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
 
     const body = xml.serialize(doc);
     const response = await this._put('changeset/create', body, {
-      headers: { ...this._requestHeaders, 'X-Workspace': workspaceId },
+      headers: { 'X-Workspace': workspaceId },
     });
 
     return Number(await response.text());
@@ -441,7 +441,6 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
     await this._post(`changeset/${changesetId}/upload`, changesetXml, {
       headers: {
         'Content-Type': 'application/xml',
-        'Authorization': this._requestHeaders['Authorization'],
         'X-Workspace': workspaceId,
       },
     });
@@ -468,10 +467,7 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
     body.append('text', message);
 
     await this._post(`changeset/${changesetId}/comment`, body, {
-      headers: {
-        'Authorization': this._requestHeaders['Authorization'],
-        'X-Workspace': workspaceId,
-      },
+      headers: { 'X-Workspace': workspaceId },
     });
   }
 
@@ -484,7 +480,6 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
 
     const response = await this._get(`notes/search.json?${params}`, {
       headers: {
-        ...this._requestHeaders,
         'Accept': 'application/json',
         'X-Workspace': workspaceId,
       },
@@ -497,7 +492,6 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
     const bboxParam = await this.getExportBbox(workspaceId);
     const response = await this._get(`map.json?bbox=${bboxParam}`, {
       headers: {
-        ...this._requestHeaders,
         'Accept': 'application/json',
         'X-Workspace': workspaceId
       }
@@ -510,7 +504,6 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
     const bboxParam = await this.getExportBbox(workspaceId);
     const response = await this._get(`map?bbox=${bboxParam}`, {
       headers: {
-        ...this._requestHeaders,
         'Accept': 'application/xml',
         'X-Workspace': workspaceId
       }
@@ -525,17 +518,23 @@ export class OsmApiClient extends BaseHttpClient implements ICancelableClient {
     }
   }
 
-  async _send(url: string, method: string, body?: any, config?: object): Promise<Response> {
+  override async _send(
+    url: string,
+    method: string,
+    body?: HttpBody,
+    config?: FetchConfig,
+  ): Promise<Response> {
     try {
       await this.#tdeiClient.tryRefreshAuth();
       this.#setAuthHeader();
 
-      const requestOptions = {
-        credentials: 'include'
-      }
+      const requestOptions: FetchConfig = {
+        credentials: 'include',
+      };
 
       return await super._send(url, method, body, { ...requestOptions, ...config });
-    } catch (e: any) {
+    }
+    catch (e: unknown) {
       if (e instanceof BaseHttpClientError) {
         throw new OsmApiClientError(e.response);
       }

--- a/services/tdei.ts
+++ b/services/tdei.ts
@@ -1,6 +1,11 @@
 import { BlobReader, BlobWriter, ZipReader } from '@zip.js/zip.js';
 
-import { BaseHttpClient, BaseHttpClientError } from '~/services/http';
+import {
+  BaseHttpClient,
+  BaseHttpClientError,
+  type FetchConfig,
+  type HttpBody,
+} from '~/services/http';
 import type { ICancelableClient } from '~/services/loading';
 import type {
   TdeiFeedback,
@@ -284,9 +289,7 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
       resource += '?derived_from_dataset_id=' + tdeiRecordId;
     }
 
-    const response = await this._post(resource, body, {
-      headers: { 'Authorization': this._requestHeaders['Authorization'] }
-    });
+    const response = await this._post(resource, body);
 
     return await response.text();
   }
@@ -308,9 +311,7 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
       resource += '?derived_from_dataset_id=' + tdeiRecordId;
     }
 
-    const response = await this._post(resource, body, {
-      headers: { 'Authorization': this._requestHeaders['Authorization'] }
-    });
+    const response = await this._post(resource, body);
 
     return await response.text();
   }
@@ -335,10 +336,7 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
       await new Promise(resolve => setTimeout(resolve, 4000));
 
       const statusResponse = await this._get(`jobs?job_id=${jobId}&tdei_project_group_id=${projectGroupId}`, {
-        headers: {
-          'Accept': 'application/text',
-          'Authorization': this._requestHeaders['Authorization']
-        }
+        headers: { 'Accept': 'application/text' }
       });
       const statusBody = (await statusResponse.json())[0];
       const statusText = statusBody.status.toLowerCase();
@@ -424,14 +422,20 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     }
   }
 
-  override async _send(url: string, method: string, body?: any, config?: object): Promise<Response> {
+  override async _send(
+    url: string,
+    method: string,
+    body?: HttpBody,
+    config?: FetchConfig,
+  ): Promise<Response> {
     try {
       if (this.#auth.needsRefresh) {
         await this.refreshToken();
       }
 
       return await super._send(url, method, body, config);
-    } catch (e: any) {
+    }
+    catch (e: unknown) {
       if (e instanceof BaseHttpClientError) {
         throw new TdeiClientError(e.response);
       }
@@ -515,13 +519,19 @@ export class TdeiUserClient extends BaseHttpClient implements ICancelableClient 
     }
   }
 
-  override async _send(url: string, method: string, body?: any, config?: object): Promise<Response> {
+  override async _send(
+    url: string,
+    method: string,
+    body?: HttpBody,
+    config?: FetchConfig,
+  ): Promise<Response> {
     try {
       await this.#tdeiClient.tryRefreshAuth();
       this.#setAuthHeader();
 
       return await super._send(url, method, body, config);
-    } catch (e: any) {
+    }
+    catch (e: unknown) {
       if (e instanceof BaseHttpClientError) {
         throw new TdeiUserClientError(e.response);
       }

--- a/services/tdei.ts
+++ b/services/tdei.ts
@@ -242,13 +242,17 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
   }
 
   async downloadOswDataset(tdeiRecordId: string, format: string = 'osw'): Promise<Blob> {
-    const response = await this._sendTest(`osw/${tdeiRecordId}?format=${format}`, 'GET');
+    const response = await this._get(`osw/${tdeiRecordId}?format=${format}`, {
+      headers: { Accept: '*/*' },
+    });
 
     return (await response.blob());
   }
 
   async downloadPathwaysDataset(tdeiDatasetId: string): Promise<Blob> {
-    const response = await this._sendTest(`gtfs-pathways/${tdeiDatasetId}`, 'GET');
+    const response = await this._get(`gtfs-pathways/${tdeiDatasetId}`, {
+      headers: { Accept: '*/*' },
+    });
 
     return (await response.blob());
   }
@@ -328,16 +332,14 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     const filename = sourceFormat === 'osw' ? 'osw.zip' : 'osm.xml';
     body.append('file', new File([dataset], filename));
 
-    const jobResponse = await this._sendTest('osw/convert', 'POST', body);
+    const jobResponse = await this._post('osw/convert', body);
     const jobId = (await jobResponse.text());
 
     while (true) {
       console.info(`Waiting for dataset conversion job ${jobId}...`);
       await new Promise(resolve => setTimeout(resolve, 4000));
 
-      const statusResponse = await this._get(`jobs?job_id=${jobId}&tdei_project_group_id=${projectGroupId}`, {
-        headers: { 'Accept': 'application/text' }
-      });
+      const statusResponse = await this._get(`jobs?job_id=${jobId}&tdei_project_group_id=${projectGroupId}`);
       const statusBody = (await statusResponse.json())[0];
       const statusText = statusBody.status.toLowerCase();
 
@@ -350,7 +352,9 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
       }
     }
 
-    const fileResponse = await this._sendTest(`job/download/${jobId}`, 'GET');
+    const fileResponse = await this._get(`job/download/${jobId}`, {
+      headers: { 'Accept': '*/*' },
+    });
 
     return await fileResponse.blob();
   }

--- a/services/workspaces.ts
+++ b/services/workspaces.ts
@@ -1,4 +1,9 @@
-import { BaseHttpClient, BaseHttpClientError } from "~/services/http";
+import {
+  BaseHttpClient,
+  BaseHttpClientError,
+  type FetchConfig,
+  type HttpBody,
+} from '~/services/http';
 import { buildPathwaysCsvArchive } from '~/services/pathways';
 import { compareStringAsc } from '~/util/compare';
 
@@ -238,15 +243,16 @@ export class WorkspacesClient extends BaseHttpClient implements ICancelableClien
   override async _send(
     url: string,
     method: string,
-    body?: any,
-    config?: object
+    body?: HttpBody,
+    config?: FetchConfig,
   ): Promise<Response> {
     try {
       await this.#tdeiClient.tryRefreshAuth();
       this.#setAuthHeader();
 
       return await super._send(url, method, body, config);
-    } catch (e) {
+    }
+    catch (e: unknown) {
       if (e instanceof BaseHttpClientError) {
         throw new WorkspacesClientError(e.response);
       }


### PR DESCRIPTION
This cleans up the abstraction for HTTP request header configuration in the various API clients by merging headers instead of overwriting them.

This also cleans up some old HTTP testing code which resolves some potential auth token refresh issues in TDEI calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR refactors HTTP client header handling across the frontend services to merge headers instead of overwriting them, and removes legacy testing code. The changes introduce type-safe configurations for HTTP requests and centralize header management in the base HTTP client.

## Changes by File

### services/http.ts
- Added exported types `FetchConfig` (based on `RequestInit` with optional typed headers) and `HttpBody` (union of `BodyInit | object`)
- Refactored `BaseHttpClient._send` pipeline to merge default headers with per-request headers from `FetchConfig`
- Improved body handling: FormData strips the `Content-Type` header to allow browser defaults, and JSON stringification is determined by both resolved `Content-Type` and runtime body type
- Removed the `_sendTest` helper method, simplifying the test code cleanup
- Updated all request method signatures (`_get`, `_post`, `_put`, `_patch`, `_delete`) to use the new `FetchConfig` type

### services/osm.ts
- Updated method signature for `_send` override to use typed `HttpBody` and `FetchConfig` parameters
- Changed default `Accept` header from `text/plain` to `*/*`
- Refactored `provisionUser` to pass JSON objects directly with `Content-Type: application/json` instead of manually stringifying
- Removed per-request spreading of internal `_requestHeaders` across multiple methods (workspace/element/node/way retrieval, changeset operations, notes search, export)
- Centralized auth handling: `_send` override now calls `tryRefreshAuth()` before sending and re-applies auth headers via `#setAuthHeader()`, then merges `credentials: 'include'` with provided config

### services/tdei.ts
- Updated `_send` override signatures in both `TdeiClient` and `TdeiUserClient` to use typed `HttpBody` and `FetchConfig` parameters
- Replaced `_sendTest` calls with `_get` for dataset downloads (`downloadOswDataset`, `downloadPathwaysDataset`)
- Removed explicit per-request `Authorization` header injection from upload methods
- Simplified dataset conversion flow by removing manual `Accept`/`Authorization` header handling
- Preserved refresh-before-send behavior in both client classes

### services/workspaces.ts
- Updated `WorkspacesClient._send` method signature to use typed `HttpBody` and `FetchConfig` parameters instead of loose types
- Runtime behavior preserved: auth refresh, header setting, and error wrapping remain unchanged

## Key Improvements
- Centralized header merging logic prevents accidental header overwriting
- Type-safe HTTP configuration across all services
- Removal of `_sendTest` test helper reduces code duplication
- Consistent auth token refresh handling, addressing potential token refresh issues in TDEI calls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TaskarCenterAtUW/workspaces-frontend/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->