### PR TITLE
Added deployment trigger

### DIFF
--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -5,7 +5,7 @@ on:
             environment:
                 description: 'Environment to deploy to'
                 required: true
-                default: 'development'
+                default: 'develop'
                 type: choice
                 options:
                     - production
@@ -24,7 +24,7 @@ jobs:
               run: |
                 case "${{ inputs.environment }}" in
                     testing)     echo "target_env=Testing" >> $GITHUB_OUTPUT ;;
-                    development) echo "target_env=dev" >> $GITHUB_OUTPUT ;;
+                    develop) echo "target_env=dev" >> $GITHUB_OUTPUT ;;
                     staging)     echo "target_env=stage" >> $GITHUB_OUTPUT ;;
                     production)  echo "target_env=prod" >> $GITHUB_OUTPUT ;;
                 esac
@@ -64,3 +64,4 @@ jobs:
                     api_location: "" # Api source code path - optional
                     output_location: "" # Built app content directory - optional
                     skip_app_build: true
+                    production_branch: ${{ inputs.environment }}

--- a/.github/workflows/trigger-deploy-on-merge.yml
+++ b/.github/workflows/trigger-deploy-on-merge.yml
@@ -1,0 +1,21 @@
+name: Trigger Deployment on Pull Request Merge
+on:
+    pull_request:
+        types: [closed]
+        branches: [develop, staging, production, testing]
+permissions:
+    contents: read
+    actions: write
+
+jobs:
+    deploy-frontend:
+        runs-on: ubuntu-latest
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            - name: Trigger Frontend Deployment Workflow
+              run: |
+                gh workflow run deploy-to-azure.yml \
+                    --repo ${{ github.repository }} \
+                    --ref ${{ github.base_ref }} \
+                    --field environment=${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
Added deployment trigger to deploy to Azure Static Webapps
This pull request introduces updates to the deployment workflows, mainly to improve consistency in environment naming and to automate deployments upon pull request merges. The most important changes are grouped below:

**Workflow Automation:**

* Added a new workflow `.github/workflows/trigger-deploy-on-merge.yml` that triggers the deployment process automatically when a pull request is merged into one of the main branches (`develop`, `staging`, `production`, or `testing`).

**Environment Naming Consistency:**

* Changed the default environment input in `.github/workflows/deploy-to-azure.yml` from `development` to `develop` to match branch naming conventions.
* Updated the environment mapping in the deployment workflow to use `develop` instead of `development`.

**Deployment Parameter Improvements:**

* Added a new parameter `production_branch` to the deploy-to-azure workflow, set to the selected environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added an automated Azure Static Web Apps deployment trigger for merged pull requests targeting `develop`, `staging`, `production`, or `testing`.
- Renamed the default deployment environment from `development` to `develop` and updated its mapping.
- Added `production_branch` configuration using the selected deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->