### PR TITLE
Update trigger-deploy-on-merge.yml

### DIFF
--- a/.github/workflows/trigger-deploy-on-merge.yml
+++ b/.github/workflows/trigger-deploy-on-merge.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
     deploy-frontend:
+        if: github.event.pull_request.merged == true
         runs-on: ubuntu-latest
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Trigger only on pull request merge
This pull request makes a small change to the deployment workflow, ensuring that the `deploy-frontend` job only runs when a pull request is merged. 

* Added a conditional (`if: github.event.pull_request.merged == true`) to the `deploy-frontend` job in `.github/workflows/trigger-deploy-on-merge.yml` to prevent deployments on unmerged pull requests.