### PR TITLE
Edit Project: Improve project save toasts and CSS layout

### DIFF
--- a/pages/workspace/[id]/projects/[projectId]/edit.vue
+++ b/pages/workspace/[id]/projects/[projectId]/edit.vue
@@ -800,9 +800,6 @@ async function handleSave() {
         },
       );
     }
-
-    toast.success('Project updated', { clearOnUrlChange: false });
-    await navigateAfterSave();
   }
   catch (error) {
     pageErrorMessage.value = await resolveHttpErrorMessage(
@@ -810,9 +807,19 @@ async function handleSave() {
       'Project changes could not be saved.',
     );
     toast.error(pageErrorMessage.value);
+    return;
   }
   finally {
     saving.value = false;
+  }
+
+  toast.success('Project updated', { clearOnUrlChange: false });
+
+  try {
+    await navigateAfterSave();
+  }
+  catch {
+    toast.warning('The project was updated, but the next page could not be opened. Please reload.');
   }
 }
 

--- a/pages/workspace/[id]/projects/[projectId]/edit.vue
+++ b/pages/workspace/[id]/projects/[projectId]/edit.vue
@@ -801,7 +801,7 @@ async function handleSave() {
       );
     }
 
-    toast.success('Project updated');
+    toast.success('Project updated', { clearOnUrlChange: false });
     await navigateAfterSave();
   }
   catch (error) {
@@ -809,6 +809,7 @@ async function handleSave() {
       error,
       'Project changes could not be saved.',
     );
+    toast.error(pageErrorMessage.value);
   }
   finally {
     saving.value = false;

--- a/pages/workspace/[id]/projects/[projectId]/index.vue
+++ b/pages/workspace/[id]/projects/[projectId]/index.vue
@@ -1372,6 +1372,7 @@ function escapeHtml(value: string) {
 .project-detail-summary-item {
   display: flex;
   gap: 0.9375rem;
+  min-width: 0;
 }
 
 .project-detail-summary-item span {
@@ -1381,9 +1382,12 @@ function escapeHtml(value: string) {
 }
 
 .project-detail-summary-item strong {
+  flex: 1;
+  min-width: 0;
   color: $text-secondary;
   font-size: 1rem;
   font-weight: 400;
+  overflow-wrap: anywhere;
 }
 
 .project-detail-copy-card {


### PR DESCRIPTION
## Bug Fixes
This pull request makes improvements to the project editing and detail UI, focusing on user feedback and layout robustness. The most important changes are:

**User feedback enhancements:**

* The `handleSave` function in `edit.vue` now displays a success toast with `{ clearOnUrlChange: false }` to prevent the toast from being cleared on navigation, and shows an error toast if saving fails. 

**UI layout improvements:**

* `.project-detail-summary-item` in `index.vue` now has `min-width: 0` to better handle flexbox sizing and prevent overflow issues. 
* `.project-detail-summary-item strong` is updated with `flex: 1`, `min-width: 0`, and `overflow-wrap: anywhere` to improve text wrapping and ensure the layout remains stable with long content. 

## Screenshots
|  Before |  After |
|---|---|
|  <img width="1463" height="836" alt="Screenshot 2026-08-05 at 11 46 17 AM" src="https://github.com/user-attachments/assets/6b496068-3091-4186-ad93-a5a71a83a1b4" /> | <img width="1470" height="830" alt="Screenshot 2026-08-05 at 11 46 02 AM" src="https://github.com/user-attachments/assets/75cca849-e256-4e55-80cf-893afad531d1" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserved the save success toast across URL changes.
- Added an error toast when saving fails.
- Improved project summary layout for long values.
- Allowed summary items to shrink and wrap content at arbitrary points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->