### PR TITLE
Bugfix: Workspaces settings & Dataset Picker

### DIFF
--- a/components/DatasetPicker.vue
+++ b/components/DatasetPicker.vue
@@ -1,58 +1,267 @@
 <template>
-  <input
-    v-model="searchText"
-    type="text"
-    placeholder="Start typing a dataset name to filter datasets..."
-    aria-label="Dataset Filter"
-    class="form-control"
+  <div
+    ref="pickerRef"
+    class="position-relative dataset-picker"
+    @focusout="onFocusOut"
   >
-  <select
-    v-model="model"
-    class="dataset-picker form-select"
-    aria-label="Dataset Selection"
-  >
-    <option
-      value="null"
-      disabled
+    <input
+      :id="props.id"
+      v-model="searchText"
+      type="text"
+      class="form-select"
+      :disabled="props.disabled"
+      placeholder="Search released and accessible datasets..."
+      aria-label="Dataset Selection"
+      role="combobox"
+      aria-autocomplete="list"
+      :aria-expanded="isOpen"
+      aria-controls="dataset-picker-options"
+      autocomplete="off"
+      @focus="onFocus"
+      @click="isOpen = true"
+      @input="onInput"
+      @keydown="onKeydown"
     >
-      Select a (matching) dataset...
-    </option>
-    <option
-      v-for="ds in datasets"
-      :key="ds.id"
-      :value="ds.id"
+
+    <div
+      v-if="isOpen"
+      class="dataset-dropdown position-absolute w-100 mt-1"
+      @mousedown.prevent
     >
-      {{ ds.name }} (version {{ ds.version }})
-    </option>
-  </select>
+      <div class="dataset-header">
+        <span
+          v-if="datasets.length > 0"
+          class="dataset-count"
+        >
+          Showing first {{ datasets.length }} matching dataset{{ datasets.length !== 1 ? 's' : '' }}
+          <span v-if="datasets.length === pageSize">&#183; Refine your search for more results</span>
+        </span>
+        <span
+          v-if="loading"
+          class="spinner-border spinner-border-sm ms-auto"
+          role="status"
+          aria-label="Loading datasets"
+        />
+      </div>
+
+      <div
+        ref="listRef"
+        class="dataset-list-wrap"
+      >
+        <ul
+          id="dataset-picker-options"
+          class="list-group list-group-flush"
+          role="listbox"
+        >
+          <li
+            v-if="errorMessage && !loading"
+            class="list-group-item text-danger"
+          >
+            {{ errorMessage }}
+          </li>
+          <li
+            v-else-if="datasets.length === 0 && !loading"
+            class="list-group-item text-muted"
+          >
+            No datasets found.
+          </li>
+          <li
+            v-for="(dataset, index) in datasets"
+            :id="`dataset-item-${index}`"
+            :key="dataset.id"
+            class="list-group-item list-group-item-action cursor-pointer"
+            :class="{ 'highlighted': activeIndex === index, 'fw-bold': model === dataset.id }"
+            role="option"
+            :aria-selected="model === dataset.id"
+            @click="selectDataset(dataset)"
+            @mouseenter="activeIndex = index"
+          >
+            <div>{{ formatDataset(dataset) }}</div>
+            <small
+              v-if="dataset.projectGroupName"
+              class="text-muted"
+            >Source project group: {{ dataset.projectGroupName }}</small>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
+import { nextTick, onUnmounted, ref, watch } from 'vue'
 import { tdeiClient } from '~/services/index'
 import type { TdeiDatasetSummary } from '~/types/tdei'
 
-const model = defineModel<string | null>({ required: true });
-const props = defineProps({
-  projectGroupId: {
-    type: String,
-    required: true
-  }
-});
+const pageSize = 10
+const props = withDefaults(defineProps<{
+  id?: string;
+  disabled?: boolean;
+  selectedDataset?: TdeiDatasetSummary;
+}>(), {
+  disabled: false,
+  selectedDataset: undefined,
+})
+const model = defineModel<string | null>({ required: true })
 
-const { projectGroupId } = toRefs(props);
-const searchText = ref('');
-const datasets = ref<TdeiDatasetSummary[]>([]);
-refreshDatasets(projectGroupId.value, searchText.value);
+const pickerRef = ref<HTMLElement | null>(null)
+const listRef = ref<HTMLElement | null>(null)
+const searchText = ref('')
+const selectedText = ref('')
+const datasets = ref<TdeiDatasetSummary[]>([])
+const isOpen = ref(false)
+const loading = ref(false)
+const activeIndex = ref(-1)
+const errorMessage = ref('')
 
-watch(projectGroupId, val => refreshDatasets(val, searchText.value));
-watch(searchText, val => refreshDatasets(projectGroupId.value, val));
+let debounceId: ReturnType<typeof setTimeout>
+let requestSequence = 0
+let hasLoaded = false
 
-async function refreshDatasets(projectGroupId: string, name: string) {
-  datasets.value = (await tdeiClient.getDatasetsByProjectGroupAndName(projectGroupId, name))
-    .sort((a, b) => a.name.localeCompare(b.name));
+function formatDataset(dataset: TdeiDatasetSummary) {
+  return dataset.version
+    ? `${dataset.name} (version ${dataset.version})`
+    : dataset.name
+}
 
-  if (datasets.value.length === 0) {
-    model.value = null;
+watch(
+  () => props.selectedDataset,
+  (dataset) => {
+    if (dataset && dataset.id === model.value) {
+      selectedText.value = formatDataset(dataset)
+      searchText.value = selectedText.value
+    }
+  },
+  { immediate: true },
+)
+
+async function loadDatasets(name: string) {
+  const requestId = ++requestSequence
+  loading.value = true
+  errorMessage.value = ''
+  activeIndex.value = -1
+
+  try {
+    const results = await tdeiClient.getAvailableDatasetsByName(name, 1, pageSize)
+    if (requestId === requestSequence) {
+      datasets.value = results
+      hasLoaded = true
+    }
+  } catch (error) {
+    if (requestId === requestSequence) {
+      datasets.value = []
+      errorMessage.value = 'Unable to load datasets. Please try again.'
+    }
+    console.error(error)
+  } finally {
+    if (requestId === requestSequence) loading.value = false
   }
 }
+
+function onInput() {
+  model.value = null
+  selectedText.value = ''
+  isOpen.value = true
+  requestSequence++
+  datasets.value = []
+  errorMessage.value = ''
+  loading.value = true
+  clearTimeout(debounceId)
+  debounceId = setTimeout(() => loadDatasets(searchText.value.trim()), 300)
+}
+
+function selectDataset(dataset: TdeiDatasetSummary) {
+  model.value = dataset.id
+  selectedText.value = formatDataset(dataset)
+  searchText.value = selectedText.value
+  isOpen.value = false
+}
+
+function onFocus(event: FocusEvent) {
+  isOpen.value = true
+  if (!hasLoaded && !loading.value) loadDatasets('')
+  ;(event.target as HTMLInputElement).select()
+}
+
+function closeDropdown() {
+  isOpen.value = false
+  if (model.value) searchText.value = selectedText.value
+}
+
+function onFocusOut(event: FocusEvent) {
+  if (!pickerRef.value?.contains(event.relatedTarget as Node)) closeDropdown()
+}
+
+function scrollToActive() {
+  nextTick(() => {
+    const active = listRef.value?.querySelector(`#dataset-item-${activeIndex.value}`) as HTMLElement | null
+    active?.scrollIntoView({ block: 'nearest' })
+  })
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeDropdown()
+    return
+  }
+
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault()
+    isOpen.value = true
+    const direction = event.key === 'ArrowDown' ? 1 : -1
+    activeIndex.value = Math.min(
+      datasets.value.length - 1,
+      Math.max(0, activeIndex.value + direction),
+    )
+    scrollToActive()
+    return
+  }
+
+  if (event.key === 'Enter' && isOpen.value && activeIndex.value >= 0) {
+    event.preventDefault()
+    const dataset = datasets.value[activeIndex.value]
+    if (dataset) selectDataset(dataset)
+  }
+}
+
+onUnmounted(() => clearTimeout(debounceId))
 </script>
+
+<style lang="scss" scoped>
+@import "assets/scss/theme.scss";
+
+.cursor-pointer {
+  cursor: pointer;
+}
+.dataset-dropdown {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0.375rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  overflow: hidden;
+  z-index: 1000;
+}
+.dataset-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 12px;
+  border-bottom: 1px solid $gray-200;
+  background: $gray-100;
+  min-height: 30px;
+}
+.dataset-count {
+  color: $gray-700;
+  flex: 1;
+  font-size: 0.74rem;
+}
+.dataset-list-wrap {
+  max-height: 260px;
+  overflow-y: auto;
+}
+.list-group-item.highlighted {
+  background-color: rgba(13, 110, 253, 0.15);
+  color: inherit;
+}
+</style>

--- a/components/DatasetPicker.vue
+++ b/components/DatasetPicker.vue
@@ -252,9 +252,7 @@ function onFocus(event: FocusEvent) {
 
 function closeDropdown() {
   isOpen.value = false;
-  if (model.value) {
-    searchText.value = selectedText.value;
-  }
+  searchText.value = model.value ? selectedText.value : '';
 }
 
 function onFocusOut(event: FocusEvent) {

--- a/components/DatasetPicker.vue
+++ b/components/DatasetPicker.vue
@@ -10,12 +10,15 @@
       type="text"
       class="form-select"
       :disabled="props.disabled"
+      :required="props.required"
       placeholder="Search released and accessible datasets..."
       aria-label="Dataset Selection"
       role="combobox"
       aria-autocomplete="list"
       :aria-expanded="isOpen"
-      aria-controls="dataset-picker-options"
+      :aria-controls="listboxId"
+      :aria-activedescendant="activeOptionId"
+      :aria-required="props.required"
       autocomplete="off"
       @focus="onFocus"
       @click="isOpen = true"
@@ -30,44 +33,47 @@
     >
       <div class="dataset-header">
         <span
-          v-if="datasets.length > 0"
+          v-if="datasetOptions.length > 0"
           class="dataset-count"
         >
-          Showing first {{ datasets.length }} matching dataset{{ datasets.length !== 1 ? 's' : '' }}
-          <span v-if="datasets.length === pageSize">&#183; Refine your search for more results</span>
+          {{ resultSummary }}
         </span>
         <span
           v-if="loading"
           class="spinner-border spinner-border-sm ms-auto"
-          role="status"
-          aria-label="Loading datasets"
+          aria-hidden="true"
         />
       </div>
 
-      <div
-        ref="listRef"
-        class="dataset-list-wrap"
-      >
+      <span
+        class="visually-hidden"
+        role="status"
+        aria-live="polite"
+      >{{ statusMessage }}</span>
+
+      <div class="dataset-list-wrap">
+        <p
+          v-if="errorMessage && !loading"
+          class="list-group-item text-danger mb-0"
+        >
+          {{ errorMessage }}
+        </p>
+        <p
+          v-else-if="datasetOptions.length === 0 && !loading"
+          class="list-group-item text-muted mb-0"
+        >
+          No datasets found.
+        </p>
+
         <ul
-          id="dataset-picker-options"
+          :id="listboxId"
           class="list-group list-group-flush"
           role="listbox"
+          :aria-busy="loading"
         >
           <li
-            v-if="errorMessage && !loading"
-            class="list-group-item text-danger"
-          >
-            {{ errorMessage }}
-          </li>
-          <li
-            v-else-if="datasets.length === 0 && !loading"
-            class="list-group-item text-muted"
-          >
-            No datasets found.
-          </li>
-          <li
-            v-for="(dataset, index) in datasets"
-            :id="`dataset-item-${index}`"
+            v-for="(dataset, index) in datasetOptions"
+            :id="getOptionId(index)"
             :key="dataset.id"
             class="list-group-item list-group-item-action cursor-pointer"
             :class="{ 'highlighted': activeIndex === index, 'fw-bold': model === dataset.id }"
@@ -76,7 +82,7 @@
             @click="selectDataset(dataset)"
             @mouseenter="activeIndex = index"
           >
-            <div>{{ formatDataset(dataset) }}</div>
+            <div>{{ dataset.displayName }}</div>
             <small
               v-if="dataset.projectGroupName"
               class="text-muted"
@@ -89,179 +95,257 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onUnmounted, ref, watch } from 'vue'
-import { tdeiClient } from '~/services/index'
-import type { TdeiDatasetSummary } from '~/types/tdei'
+import { computed, nextTick, onUnmounted, ref, useId, watch } from 'vue';
+import { tdeiClient } from '~/services/index';
+import type { TdeiDatasetSummary } from '~/types/tdei';
 
-const pageSize = 10
+interface DatasetOption extends TdeiDatasetSummary {
+  displayName: string;
+}
+
+const pageSize = 10;
 const props = withDefaults(defineProps<{
   id?: string;
   disabled?: boolean;
+  required?: boolean;
   selectedDataset?: TdeiDatasetSummary;
 }>(), {
   disabled: false,
-  selectedDataset: undefined,
-})
-const model = defineModel<string | null>({ required: true })
+  required: false,
+  selectedDataset: undefined
+});
+const model = defineModel<string | null>({ required: true });
 
-const pickerRef = ref<HTMLElement | null>(null)
-const listRef = ref<HTMLElement | null>(null)
-const searchText = ref('')
-const selectedText = ref('')
-const datasets = ref<TdeiDatasetSummary[]>([])
-const isOpen = ref(false)
-const loading = ref(false)
-const activeIndex = ref(-1)
-const errorMessage = ref('')
+const generatedId = useId();
+const listboxId = computed(() => `${props.id || `dataset-picker-${generatedId}`}-options`);
+const pickerRef = ref<HTMLElement | null>(null);
+const searchText = ref('');
+const selectedText = ref('');
+const datasets = ref<TdeiDatasetSummary[]>([]);
+const isOpen = ref(false);
+const loading = ref(false);
+const activeIndex = ref(-1);
+const errorMessage = ref('');
 
-let debounceId: ReturnType<typeof setTimeout>
-let requestSequence = 0
-let hasLoaded = false
+const datasetOptions = computed<DatasetOption[]>(() => datasets.value.map(dataset => ({
+  ...dataset,
+  displayName: formatDataset(dataset)
+})));
+const activeOptionId = computed(() => isOpen.value && activeIndex.value >= 0
+  ? getOptionId(activeIndex.value)
+  : undefined);
+const resultSummary = computed(() => {
+  const count = datasetOptions.value.length;
+  const prefix = count === pageSize ? 'Showing first' : 'Showing';
+  const summary = `${prefix} ${count} matching dataset${count === 1 ? '' : 's'}`;
+
+  return count === pageSize
+    ? `${summary} · Refine your search for more results`
+    : summary;
+});
+const statusMessage = computed(() => {
+  if (loading.value) {
+    return 'Loading datasets.';
+  }
+
+  if (errorMessage.value) {
+    return errorMessage.value;
+  }
+
+  if (!hasLoaded.value) {
+    return '';
+  }
+
+  return datasetOptions.value.length > 0
+    ? resultSummary.value
+    : 'No datasets found.';
+});
+
+let debounceId: ReturnType<typeof setTimeout>;
+let requestSequence = 0;
+const hasLoaded = ref(false);
+let requestAbortController: AbortController | undefined;
 
 function formatDataset(dataset: TdeiDatasetSummary) {
   return dataset.version
     ? `${dataset.name} (version ${dataset.version})`
-    : dataset.name
+    : dataset.name;
+}
+
+function getOptionId(index: number) {
+  return `${listboxId.value}-option-${index}`;
 }
 
 watch(
   () => props.selectedDataset,
   (dataset) => {
     if (dataset && dataset.id === model.value) {
-      selectedText.value = formatDataset(dataset)
-      searchText.value = selectedText.value
+      selectedText.value = formatDataset(dataset);
+      searchText.value = selectedText.value;
     }
   },
-  { immediate: true },
-)
+  { immediate: true }
+);
 
 async function loadDatasets(name: string) {
-  const requestId = ++requestSequence
-  loading.value = true
-  errorMessage.value = ''
-  activeIndex.value = -1
+  requestAbortController?.abort();
+  const abortController = new AbortController();
+  requestAbortController = abortController;
+  const requestId = ++requestSequence;
+  const client = tdeiClient.clone(abortController.signal);
+  loading.value = true;
+  errorMessage.value = '';
+  activeIndex.value = -1;
 
   try {
-    const results = await tdeiClient.getAvailableDatasetsByName(name, 1, pageSize)
+    const results = await client.getAvailableDatasetsByName(name, 1, pageSize);
     if (requestId === requestSequence) {
-      datasets.value = results
-      hasLoaded = true
+      datasets.value = results;
+      hasLoaded.value = true;
     }
-  } catch (error) {
+  }
+  catch (error) {
+    if (abortController.signal.aborted) {
+      return;
+    }
+
     if (requestId === requestSequence) {
-      datasets.value = []
-      errorMessage.value = 'Unable to load datasets. Please try again.'
+      datasets.value = [];
+      errorMessage.value = 'Unable to load datasets. Please try again.';
     }
-    console.error(error)
-  } finally {
-    if (requestId === requestSequence) loading.value = false
+    console.error(error);
+  }
+  finally {
+    if (requestId === requestSequence) {
+      loading.value = false;
+    }
   }
 }
 
 function onInput() {
-  model.value = null
-  selectedText.value = ''
-  isOpen.value = true
-  requestSequence++
-  datasets.value = []
-  errorMessage.value = ''
-  loading.value = true
-  clearTimeout(debounceId)
-  debounceId = setTimeout(() => loadDatasets(searchText.value.trim()), 300)
+  model.value = null;
+  selectedText.value = '';
+  isOpen.value = true;
+  requestAbortController?.abort();
+  requestSequence++;
+  datasets.value = [];
+  errorMessage.value = '';
+  loading.value = true;
+  clearTimeout(debounceId);
+  debounceId = setTimeout(() => loadDatasets(searchText.value.trim()), 300);
 }
 
 function selectDataset(dataset: TdeiDatasetSummary) {
-  model.value = dataset.id
-  selectedText.value = formatDataset(dataset)
-  searchText.value = selectedText.value
-  isOpen.value = false
+  model.value = dataset.id;
+  selectedText.value = formatDataset(dataset);
+  searchText.value = selectedText.value;
+  isOpen.value = false;
 }
 
 function onFocus(event: FocusEvent) {
-  isOpen.value = true
-  if (!hasLoaded && !loading.value) loadDatasets('')
-  ;(event.target as HTMLInputElement).select()
+  isOpen.value = true;
+  if (!hasLoaded.value && !loading.value) {
+    void loadDatasets('');
+  }
+  (event.target as HTMLInputElement).select();
 }
 
 function closeDropdown() {
-  isOpen.value = false
-  if (model.value) searchText.value = selectedText.value
+  isOpen.value = false;
+  if (model.value) {
+    searchText.value = selectedText.value;
+  }
 }
 
 function onFocusOut(event: FocusEvent) {
-  if (!pickerRef.value?.contains(event.relatedTarget as Node)) closeDropdown()
+  if (!pickerRef.value?.contains(event.relatedTarget as Node)) {
+    closeDropdown();
+  }
 }
 
 function scrollToActive() {
   nextTick(() => {
-    const active = listRef.value?.querySelector(`#dataset-item-${activeIndex.value}`) as HTMLElement | null
-    active?.scrollIntoView({ block: 'nearest' })
-  })
+    const active = document.getElementById(getOptionId(activeIndex.value));
+    active?.scrollIntoView({ block: 'nearest' });
+  });
 }
 
 function onKeydown(event: KeyboardEvent) {
   if (event.key === 'Escape') {
-    event.preventDefault()
-    closeDropdown()
-    return
+    event.preventDefault();
+    closeDropdown();
+    return;
   }
 
   if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-    event.preventDefault()
-    isOpen.value = true
-    const direction = event.key === 'ArrowDown' ? 1 : -1
+    event.preventDefault();
+    isOpen.value = true;
+    const direction = event.key === 'ArrowDown' ? 1 : -1;
     activeIndex.value = Math.min(
       datasets.value.length - 1,
-      Math.max(0, activeIndex.value + direction),
-    )
-    scrollToActive()
-    return
+      Math.max(0, activeIndex.value + direction)
+    );
+    scrollToActive();
+    return;
   }
 
   if (event.key === 'Enter' && isOpen.value && activeIndex.value >= 0) {
-    event.preventDefault()
-    const dataset = datasets.value[activeIndex.value]
-    if (dataset) selectDataset(dataset)
+    event.preventDefault();
+    const dataset = datasets.value[activeIndex.value];
+    if (dataset) {
+      selectDataset(dataset);
+    }
   }
 }
 
-onUnmounted(() => clearTimeout(debounceId))
+onUnmounted(() => {
+  clearTimeout(debounceId);
+  requestSequence++;
+  requestAbortController?.abort();
+});
 </script>
 
 <style lang="scss" scoped>
-@import "assets/scss/theme.scss";
+@import "~/assets/scss/theme.scss";
+
+$dataset-picker-list-max-height: 16.25rem;
 
 .cursor-pointer {
   cursor: pointer;
 }
+
 .dataset-dropdown {
-  background: #fff;
-  border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 0.375rem;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  background: $dropdown-bg;
+  border: $dropdown-border-width solid $dropdown-border-color;
+  border-radius: $dropdown-border-radius;
+  box-shadow: $box-shadow;
   overflow: hidden;
-  z-index: 1000;
+  z-index: $zindex-dropdown;
 }
+
 .dataset-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 5px 12px;
+  gap: $spacer * 0.5;
+  padding: $spacer * 0.25 $spacer * 0.75;
   border-bottom: 1px solid $gray-200;
   background: $gray-100;
-  min-height: 30px;
 }
+
 .dataset-count {
-  color: $gray-700;
   flex: 1;
-  font-size: 0.74rem;
+  color: $gray-700;
+  font-size: $small-font-size;
+  line-height: $line-height-sm;
 }
+
 .dataset-list-wrap {
-  max-height: 260px;
+  max-height: $dataset-picker-list-max-height;
   overflow-y: auto;
 }
+
 .list-group-item.highlighted {
-  background-color: rgba(13, 110, 253, 0.15);
+  background-color: $dropdown-active-bg;
   color: inherit;
 }
 </style>

--- a/components/dashboard/WorkspaceItem.vue
+++ b/components/dashboard/WorkspaceItem.vue
@@ -108,8 +108,8 @@ function formatTypeLabel(type: string) {
   border-left-color: var(--bs-primary);
   box-shadow: 0 8px 24px rgba(50, 0, 110, 0.14);
   position: sticky;
-  top: 1rem;
-  bottom: 1rem;
+  top: 0;
+  bottom: 0;
 }
 
 .workspace-card-main {

--- a/components/settings/panel/Apps.vue
+++ b/components/settings/panel/Apps.vue
@@ -26,7 +26,7 @@
             class="form-check-input"
             :true-value="1"
             :false-value="0"
-            :disabled="!isLead"
+            :disabled="!isLead || isSaving"
           >
           Publish this workspace for external apps
         </label>
@@ -178,10 +178,11 @@ const longFormQuestExampleUrl = import.meta.env.VITE_LONG_FORM_QUEST_EXAMPLE_URL
 
 const workspace = inject<Workspace>('workspace')!;
 const { isLead } = useWorkspaceRole();
+const isSaving = ref(false);
 
 // The quest-definition controls only apply when the workspace is published for
-// external apps, so they're disabled when "Publish" is off (or for non-leads).
-const appControlsDisabled = computed(() => !isLead.value || !workspace.externalAppAccess);
+// external apps, so they're disabled when "Publish" is off, while saving, or for non-leads.
+const appControlsDisabled = computed(() => !isLead.value || !workspace.externalAppAccess || isSaving.value);
 
 const [longFormQuestSettings] = await Promise.all([
   workspacesClient.getLongFormQuestSettings(workspace.id),
@@ -193,7 +194,6 @@ const longFormQuestDef = ref(longFormQuestSettings.definition);
 const longFormQuestUrl = ref(longFormQuestSettings.url);
 const longFormQuestError = ref<string | null>(null);
 const isDraggingQuest = ref(false);
-const isSaving = ref(false);
 
 watch(
   [

--- a/components/settings/panel/Apps.vue
+++ b/components/settings/panel/Apps.vue
@@ -146,9 +146,18 @@
       <button
         type="submit"
         class="btn btn-primary"
-        :disabled="!isLead"
+        :disabled="!isLead || isSaving"
       >
-        Save
+        <template v-if="isSaving">
+          <span
+            class="spinner-border spinner-border-sm me-2"
+            aria-hidden="true"
+          />
+          Saving&hellip;
+        </template>
+        <template v-else>
+          Save
+        </template>
       </button>
     </div><!-- .card-body -->
   </form><!-- .card -->
@@ -183,6 +192,7 @@ const longFormQuestDef = ref(longFormQuestSettings.definition);
 const longFormQuestUrl = ref(longFormQuestSettings.url);
 const longFormQuestError = ref<string | null>(null);
 const isDraggingQuest = ref(false);
+const isSaving = ref(false);
 
 watch(
   [
@@ -203,48 +213,51 @@ function onQuestFileDrop(event: DragEvent) {
 }
 
 async function saveExternalAppConfiguration() {
+  if (isSaving.value) return;
+
+  isSaving.value = true;
   clearExternalAppMessages();
 
-  let type = longFormQuestType.value;
-  let definition = longFormQuestDef.value;
-  let url = longFormQuestUrl.value;
+  try {
+    let type = longFormQuestType.value;
+    let definition = longFormQuestDef.value;
+    let url = longFormQuestUrl.value;
 
-  if (type === 'JSON') {
-    url = undefined;
+    if (type === 'JSON') {
+      url = undefined;
 
-    if (!definition) {
-      type = 'NONE';
-    }
-    else {
-      const validationResult = await validateJson(
-        definition,
-        longFormQuestSchemaUrl,
-        longFormQuestSchema,
-        'Long form quest definition',
-      );
+      if (!definition) {
+        type = 'NONE';
+      }
+      else {
+        const validationResult = await validateJson(
+          definition,
+          longFormQuestSchemaUrl,
+          longFormQuestSchema,
+          'Long form quest definition',
+        );
 
-      if (validationResult.error) {
-        longFormQuestError.value = validationResult.error;
-        return;
+        if (validationResult.error) {
+          longFormQuestError.value = validationResult.error;
+          return;
+        }
       }
     }
-  }
-  else if (type === 'URL') {
-    definition = undefined;
+    else if (type === 'URL') {
+      definition = undefined;
 
-    if (!url) {
-      type = 'NONE';
+      if (!url) {
+        type = 'NONE';
+      }
+      else if (!isHttpUrl(url)) {
+        longFormQuestError.value = 'The URL is not valid.';
+        return;
+      }
+      else {
+        url = normalizeUrl(url);
+      }
     }
-    else if (!isHttpUrl(url)) {
-      longFormQuestError.value = 'The URL is not valid.';
-      return;
-    }
-    else {
-      url = normalizeUrl(url);
-    }
-  }
 
-  try {
     await Promise.all([
       workspacesClient.updateWorkspace(workspace.id, {
         externalAppAccess: workspace.externalAppAccess,
@@ -264,6 +277,9 @@ async function saveExternalAppConfiguration() {
   catch (e) {
     const errorMessage = e instanceof Error ? e.message : 'unexpected error';
     toast.error('Failed to save changes: ' + errorMessage);
+  }
+  finally {
+    isSaving.value = false;
   }
 }
 </script>

--- a/components/settings/panel/Apps.vue
+++ b/components/settings/panel/Apps.vue
@@ -147,6 +147,7 @@
         type="submit"
         class="btn btn-primary"
         :disabled="!isLead || isSaving"
+        :aria-busy="isSaving"
       >
         <template v-if="isSaving">
           <span

--- a/components/settings/panel/Delete.vue
+++ b/components/settings/panel/Delete.vue
@@ -95,6 +95,7 @@ async function submitDelete() {
 
   try {
     await workspacesClient.deleteWorkspace(workspace.id);
+    await navigateTo('/dashboard');
   }
   catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'unexpected error';
@@ -104,7 +105,5 @@ async function submitDelete() {
   finally {
     isDeleting.value = false;
   }
-
-  await navigateTo('/dashboard');
 }
 </script>

--- a/components/settings/panel/Delete.vue
+++ b/components/settings/panel/Delete.vue
@@ -40,10 +40,20 @@
 
         <button
           class="btn btn-danger"
-          :disabled="!isLead || attestation !== 'delete'"
+          :disabled="!isLead || attestation !== 'delete' || isDeleting"
+          :aria-busy="isDeleting"
           @click="submitDelete"
         >
-          Delete this workspace
+          <template v-if="isDeleting">
+            <span
+              class="spinner-border spinner-border-sm me-2"
+              aria-hidden="true"
+            />
+            Deleting&hellip;
+          </template>
+          <template v-else>
+            Delete this workspace
+          </template>
         </button>
       </template>
     </div>
@@ -53,6 +63,7 @@
 </template>
 
 <script setup lang="ts">
+import { toast } from 'vue3-toastify';
 import { workspacesClient } from '~/services/index';
 
 import type { Workspace } from '~/types/workspaces';
@@ -62,6 +73,7 @@ const { isLead } = useWorkspaceRole();
 
 const accepted = ref(false);
 const attestation = ref('');
+const isDeleting = ref(false);
 const input = useTemplateRef<HTMLInputElement>('input');
 
 async function acceptDelete() {
@@ -75,11 +87,24 @@ async function acceptDelete() {
 }
 
 async function submitDelete() {
-  if (!isLead.value) {
+  if (!isLead.value || attestation.value !== 'delete' || isDeleting.value) {
     return;
   }
 
-  await workspacesClient.deleteWorkspace(workspace.id);
-  navigateTo('/dashboard');
+  isDeleting.value = true;
+
+  try {
+    await workspacesClient.deleteWorkspace(workspace.id);
+  }
+  catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'unexpected error';
+    toast.error('Failed to delete workspace: ' + errorMessage);
+    return;
+  }
+  finally {
+    isDeleting.value = false;
+  }
+
+  await navigateTo('/dashboard');
 }
 </script>

--- a/components/settings/panel/General.vue
+++ b/components/settings/panel/General.vue
@@ -23,9 +23,19 @@
         <button
           type="submit"
           class="btn btn-primary"
-          :disabled="!isLead"
+          :disabled="!isLead || isRenaming"
+          :aria-busy="isRenaming"
         >
-          Rename
+          <template v-if="isRenaming">
+            <span
+              class="spinner-border spinner-border-sm me-2"
+              aria-hidden="true"
+            />
+            Renaming&hellip;
+          </template>
+          <template v-else>
+            Rename
+          </template>
         </button>
       </form>
 
@@ -65,8 +75,13 @@ const workspace = inject<Workspace>('workspace')!;
 const { isLead } = useWorkspaceRole();
 const workspaceName = ref(workspace.title);
 const autoFlagReview = ref(workspace.autoFlagReview ?? false);
+const isRenaming = ref(false);
 
 async function rename() {
+  if (isRenaming.value) return;
+
+  isRenaming.value = true;
+
   try {
     await workspacesClient.updateWorkspace(workspace.id, {
       title: workspaceName.value,
@@ -80,6 +95,9 @@ async function rename() {
     else {
       toast.error('Rename failed: unexpected error');
     }
+  }
+  finally {
+    isRenaming.value = false;
   }
 }
 

--- a/components/settings/panel/General.vue
+++ b/components/settings/panel/General.vue
@@ -16,7 +16,7 @@
           <input
             v-model.trim="workspaceName"
             class="form-control"
-            :disabled="!isLead"
+            :disabled="!isLead || isRenaming"
           >
         </label>
 

--- a/components/settings/panel/Imagery.vue
+++ b/components/settings/panel/Imagery.vue
@@ -62,9 +62,19 @@
       <button
         type="submit"
         class="btn btn-primary"
-        :disabled="!isLead"
+        :disabled="!isLead || isSaving"
+        :aria-busy="isSaving"
       >
-        Save
+        <template v-if="isSaving">
+          <span
+            class="spinner-border spinner-border-sm me-2"
+            aria-hidden="true"
+          />
+          Saving&hellip;
+        </template>
+        <template v-else>
+          Save
+        </template>
       </button>
     </div><!-- .card-body -->
   </form><!-- .card -->
@@ -88,6 +98,7 @@ const imagerySchema = ref<object | undefined>();
 const imageryListDef = ref('');
 const imageryError = ref<string | null>(null);
 const isDraggingImagery = ref(false);
+const isSaving = ref(false);
 
 onMounted(async () => {
   const settings = await workspacesClient.getImagerySettings(workspace.id);
@@ -106,21 +117,24 @@ function onImageryFileDrop(event: DragEvent) {
 }
 
 async function saveImageryConfiguration() {
+  if (isSaving.value) return;
+
+  isSaving.value = true;
   clearImageryMessages();
 
-  const imageryResult = await validateJson(
-    imageryListDef.value,
-    imagerySchemaUrl,
-    imagerySchema,
-    'Imagery definition',
-  );
-
-  if (imageryResult.error) {
-    imageryError.value = imageryResult.error;
-    return;
-  }
-
   try {
+    const imageryResult = await validateJson(
+      imageryListDef.value,
+      imagerySchemaUrl,
+      imagerySchema,
+      'Imagery definition',
+    );
+
+    if (imageryResult.error) {
+      imageryError.value = imageryResult.error;
+      return;
+    }
+
     await workspacesClient.saveImageryDefSettings(workspace.id, {
       definition: imageryResult.data,
     });
@@ -129,6 +143,9 @@ async function saveImageryConfiguration() {
   catch (e) {
     const errorMessage = e instanceof Error ? e.message : 'unexpected error';
     toast.error('Failed to save changes: ' + errorMessage);
+  }
+  finally {
+    isSaving.value = false;
   }
 }
 </script>

--- a/components/settings/panel/Imagery.vue
+++ b/components/settings/panel/Imagery.vue
@@ -26,7 +26,7 @@
           :class="{ 'drag-over': isDraggingImagery }"
           rows="5"
           placeholder="Optional"
-          :disabled="!isLead"
+          :disabled="!isLead || isSaving"
           @dragover.prevent="isDraggingImagery = true"
           @dragleave.prevent="isDraggingImagery = false"
           @drop.prevent="onImageryFileDrop"

--- a/pages/workspace/[id]/settings.vue
+++ b/pages/workspace/[id]/settings.vue
@@ -6,6 +6,7 @@
 //            confirmation and sends the proper API call to the server (Swagger here: https://new-api.workspaces-stage.sidewalks.washington.edu/openapi.json)
 // @test e2e: Under "External Apps", turning on "Publish this workspace" enables the other buttons and when clicking "Save" shows a confirmation and sends
 //            the proper API call.
+// @test e2e: While External Apps settings are being saved, the Save button is disabled and displays "Saving..." to prevent duplicate submissions.
 // @test e2e: the "Custom Imagery" box is validated against the JSON schema here (https://raw.githubusercontent.com/TaskarCenterAtUW/asr-imagery-list/refs/heads/main/schema/schema.json),
 //            and a toast shown when it passes and the API call to set its value is successful on the backend.
 // @test e2e: Clicking "I understand and want to delete this workspace" shows a modal that requires the user to type in the word "delete", and when confirmed sends the proper API

--- a/pages/workspace/create/tdei.vue
+++ b/pages/workspace/create/tdei.vue
@@ -182,16 +182,16 @@ const projectGroupId = ref<string | null>(null);
 const datasetError = ref<string | null>(null);
 
 const selectedDataset = computed<TdeiDatasetSummary | undefined>(() => {
-  const detail = record.metadata?.dataset_detail
-  if (!tdeiRecordId.value || !detail?.name) return undefined
+  const detail = record.metadata?.dataset_detail;
+  if (!tdeiRecordId.value || !detail?.name) return undefined;
 
   return {
     id: tdeiRecordId.value,
     name: detail.name,
     version: detail.version,
-    projectGroupName: record.project_group?.name,
-  }
-})
+    projectGroupName: record.project_group?.name
+  };
+});
 
 watch(tdeiRecordId, val => getDatasetInfo(val));
 

--- a/pages/workspace/create/tdei.vue
+++ b/pages/workspace/create/tdei.vue
@@ -51,8 +51,8 @@
               Dataset
               <dataset-picker
                 v-model="tdeiRecordId"
-                :project-group-id="projectGroupId ?? ''"
                 :disabled="context.active"
+                :selected-dataset="selectedDataset"
                 required
               />
             </label>
@@ -165,6 +165,7 @@
 import { LoadingContext } from '~/services/loading'
 import { TdeiImporter, TdeiImporterContext } from '~/services/import/tdei';
 import { osmClient, tdeiClient, workspacesClient } from '~/services/index';
+import type { TdeiDatasetSummary } from '~/types/tdei';
 
 declare const L: any;
 
@@ -179,6 +180,18 @@ const map = ref<any>({});
 const workspaceTitle = ref('');
 const projectGroupId = ref<string | null>(null);
 const datasetError = ref<string | null>(null);
+
+const selectedDataset = computed<TdeiDatasetSummary | undefined>(() => {
+  const detail = record.metadata?.dataset_detail
+  if (!tdeiRecordId.value || !detail?.name) return undefined
+
+  return {
+    id: tdeiRecordId.value,
+    name: detail.name,
+    version: detail.version,
+    projectGroupName: record.project_group?.name,
+  }
+})
 
 watch(tdeiRecordId, val => getDatasetInfo(val));
 
@@ -223,7 +236,6 @@ async function getDatasetInfo(id: string | null) {
   }
 
   workspaceTitle.value = record.metadata?.dataset_detail?.name ?? ''
-  projectGroupId.value = record.project_group.tdei_project_group_id
   tdeiRecordId.value = record.tdei_dataset_id
 
   initMap();

--- a/pages/workspace/create/tdei.vue
+++ b/pages/workspace/create/tdei.vue
@@ -202,7 +202,9 @@ const complete = computed(() =>
   && datasetError.value === null,
 );
 
+let datasetInfoSequence = 0;
 async function getDatasetInfo(id: string | null) {
+  const requestId = ++datasetInfoSequence;
   datasetError.value = null
 
   if (id === null) {
@@ -216,7 +218,7 @@ async function getDatasetInfo(id: string | null) {
 
   await loading.wrap(tdeiClient, async (client) => {
     const info = await client.getDatasetInfo(id);
-
+    if (requestId !== datasetInfoSequence) return;
     if (!info) return
 
     // Clear stale keys from any previously loaded dataset before merging,
@@ -229,6 +231,8 @@ async function getDatasetInfo(id: string | null) {
   });
 
   await nextTick();
+
+  if (requestId !== datasetInfoSequence) return;
 
   if (!record.project_group?.tdei_project_group_id || !record.tdei_dataset_id) {
     datasetError.value = 'The selected dataset returned incomplete data. Please try a different dataset or contact support.'

--- a/services/tdei.ts
+++ b/services/tdei.ts
@@ -243,7 +243,7 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
       sort_field: 'uploaded_timestamp',
       sort_order: 'DESC',
       status: 'All',
-      name,
+      name
     });
     const response = await this._get(`datasets?${params.toString()}`);
 
@@ -252,7 +252,7 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
         id: d.tdei_dataset_id,
         name: d.metadata?.dataset_detail?.name ?? d.tdei_dataset_id,
         version: d.metadata?.dataset_detail?.version,
-        projectGroupName: d.project_group?.name,
+        projectGroupName: d.project_group?.name
       }));
   }
 

--- a/services/tdei.ts
+++ b/services/tdei.ts
@@ -250,8 +250,8 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     return (await response.json() as TdeiDatasetApiResponse[])
       .map(d => ({
         id: d.tdei_dataset_id,
-        name: d.metadata.dataset_detail.name,
-        version: d.metadata.dataset_detail.version,
+        name: d.metadata?.dataset_detail?.name ?? d.tdei_dataset_id,
+        version: d.metadata?.dataset_detail?.version,
         projectGroupName: d.project_group?.name,
       }));
   }

--- a/services/tdei.ts
+++ b/services/tdei.ts
@@ -236,11 +236,24 @@ export class TdeiClient extends BaseHttpClient implements ICancelableClient {
     return (await response.json() as TdeiDatasetApiResponse[])[0];
   }
 
-  async getDatasetsByProjectGroupAndName(projectGroupId: string, name: string): Promise<TdeiDatasetSummary[]> {
-    const response = await this._get(`datasets?tdei_project_group_id=${projectGroupId}&name=${encodeURIComponent(name)}`);
+  async getAvailableDatasetsByName(name: string, pageNo = 1, pageSize = 10): Promise<TdeiDatasetSummary[]> {
+    const params = new URLSearchParams({
+      page_no: pageNo.toString(),
+      page_size: pageSize.toString(),
+      sort_field: 'uploaded_timestamp',
+      sort_order: 'DESC',
+      status: 'All',
+      name,
+    });
+    const response = await this._get(`datasets?${params.toString()}`);
 
     return (await response.json() as TdeiDatasetApiResponse[])
-      .map(d => ({ id: d.tdei_dataset_id, name: d.metadata.dataset_detail.name, version: d.metadata.dataset_detail.version }));
+      .map(d => ({
+        id: d.tdei_dataset_id,
+        name: d.metadata.dataset_detail.name,
+        version: d.metadata.dataset_detail.version,
+        projectGroupName: d.project_group?.name,
+      }));
   }
 
   async downloadOswDataset(tdeiRecordId: string, format: string = 'osw'): Promise<Blob> {

--- a/test/e2e/contract.ts
+++ b/test/e2e/contract.ts
@@ -30,6 +30,7 @@ function pathToRegex(p: string): RegExp {
   return new RegExp(`^${re}$`);
 }
 const PATH_MATCHERS = SPEC_PATHS.map(p => ({ key: p, re: pathToRegex(p) }));
+const STATIC_SCHEMA_PATHS = new Set(['/imagery-schema.json', '/quest-schema.json']);
 
 const validatorCache = new Map<string, ReturnType<typeof ajv.compile>>();
 function validatorFor(subSchema: object, cacheKey: string) {
@@ -63,7 +64,8 @@ interface RecordedCall {
 function isNewApiRequest(req: Request): boolean {
   try {
     const url = new URL(req.url());
-    return url.hostname === 'api.test' && !url.pathname.startsWith('/tdei')
+    return url.hostname === 'api.test' && !STATIC_SCHEMA_PATHS.has(url.pathname)
+      && !url.pathname.startsWith('/tdei')
       && !url.pathname.startsWith('/osm') && !url.pathname.startsWith('/rapid')
       && !url.pathname.startsWith('/pathways');
   }

--- a/test/e2e/create-tdei.spec.ts
+++ b/test/e2e/create-tdei.spec.ts
@@ -169,7 +169,7 @@ async function fillForm(page: Page) {
 }
 
 test.describe('create workspace from TDEI', () => {
-  test('dataset picker is accessible and requests published datasets', async ({ page }) => {
+  test('dataset picker is accessible and requests all datasets', async ({ page }) => {
     await seedAuthenticatedSession(page);
     await stubHappyPath(page);
 

--- a/test/e2e/create-tdei.spec.ts
+++ b/test/e2e/create-tdei.spec.ts
@@ -162,16 +162,40 @@ async function fillForm(page: Page) {
   await pgInput.click();
   await page.getByRole('listitem').filter({ hasText: 'Puget Sound' }).first().click();
 
-  // Choose the dataset; this fires getDatasetInfo which auto-fills the title.
-  // DatasetPicker is a native <select> whose option values are dataset ids and
-  // whose display text is "{name} (version {v})"; select the first real option
-  // (index 1, after the disabled placeholder at index 0).
-  await page.getByLabel('Dataset Selection').selectOption({ index: 1 });
+  await page.getByRole('combobox', { name: 'Dataset Selection' }).click();
+  await page.getByRole('option', { name: /Downtown Sidewalks/ }).click();
 
   await expect(page.getByRole('button', { name: 'Create Workspace' })).toBeEnabled();
 }
 
 test.describe('create workspace from TDEI', () => {
+  test('dataset picker is accessible and requests published datasets', async ({ page }) => {
+    await seedAuthenticatedSession(page);
+    await stubHappyPath(page);
+
+    let listRequestUrl = '';
+    await page.route('**/tdei/datasets**', (route) => {
+      const url = new URL(route.request().url());
+      if (!url.searchParams.has('tdei_dataset_id')) {
+        listRequestUrl = url.toString();
+      }
+      return route.fulfill({ json: [TDEI_DATASET] });
+    });
+
+    await page.goto('/workspace/create/tdei');
+
+    const datasetPicker = page.getByRole('combobox', { name: 'Dataset Selection' });
+    await expect(datasetPicker).toHaveAttribute('required', '');
+    await datasetPicker.click();
+    await expect(page.getByRole('option', { name: /Downtown Sidewalks/ })).toBeVisible();
+    await expect.poll(() => listRequestUrl
+      ? new URL(listRequestUrl).searchParams.get('status')
+      : null).toBe('All');
+
+    await datasetPicker.press('ArrowDown');
+    await expect(datasetPicker).toHaveAttribute('aria-activedescendant', /-option-0$/);
+  });
+
   // @test e2e: submitting the form with valid values shows a loading state, then redirects to the dashboard with the
   //            new workspace selected (playwright snapshot the loading state)
   test('valid submit shows a loading state then redirects to the dashboard with the new workspace', async ({ page }) => {

--- a/test/e2e/settings.spec.ts
+++ b/test/e2e/settings.spec.ts
@@ -92,7 +92,7 @@ async function stubSettings(page: Page) {
     }
     return route.fallback();
   });
-  await page.route('**/imagery-schema.json', route =>
+  await page.route(/(?:imagery-schema|schema)\.json$/, route =>
     route.fulfill({ json: imagerySchema })
   );
 }
@@ -113,10 +113,15 @@ test.describe('workspace settings', () => {
     await stubSettings(page);
 
     let patchBody: unknown = null;
-    await page.route('**/workspaces/1', (route) => {
+    let releaseRename: () => void = () => {};
+    const renameGate = new Promise<void>((resolve) => {
+      releaseRename = resolve;
+    });
+    await page.route('**/workspaces/1', async (route) => {
       const req = route.request();
       if (req.method() === 'PATCH') {
         patchBody = JSON.parse(req.postData() ?? '{}');
+        await renameGate;
         return route.fulfill({ status: 204, body: '' });
       }
       return route.fallback();
@@ -130,6 +135,8 @@ test.describe('workspace settings', () => {
     await titleField.fill('Renamed Workspace');
     await general.getByRole('button', { name: 'Rename' }).click();
 
+    await expect(general.getByRole('button', { name: /Renaming/ })).toBeDisabled();
+    releaseRename();
     await expect(successToast(page)).toBeVisible();
     await expect(successToast(page)).toContainText('Workspace renamed successfully.');
     expect(patchBody).toEqual({ title: 'Renamed Workspace' });
@@ -205,6 +212,44 @@ test.describe('workspace settings', () => {
     expect(patchBody).toEqual({ externalAppAccess: 0 });
   });
 
+  // @test e2e: While External Apps settings are being saved, the Save button is
+  //            disabled and displays "Saving..." to prevent duplicate submissions.
+  test('external apps save shows a disabled saving state', async ({ page }) => {
+    await seedAuthenticatedSession(page);
+    await stubSettings(page);
+
+    let releaseSave: () => void = () => {};
+    const saveGate = new Promise<void>((resolve) => {
+      releaseSave = resolve;
+    });
+
+    await page.route('**/workspaces/1', async (route) => {
+      if (route.request().method() === 'PATCH') {
+        await saveGate;
+        return route.fulfill({ status: 204, body: '' });
+      }
+      return route.fallback();
+    });
+    await page.route('**/workspaces/1/quests/long/settings', async (route) => {
+      if (route.request().method() === 'PATCH') {
+        await saveGate;
+        return route.fulfill({ status: 204, body: '' });
+      }
+      return route.fallback();
+    });
+
+    await page.goto('/workspace/1/settings');
+
+    const apps = page.locator('form.card', { hasText: 'External Apps' });
+    const saveButton = apps.getByRole('button', { name: 'Save' });
+    await saveButton.click();
+
+    await expect(apps.getByRole('button', { name: /Saving/ })).toBeDisabled();
+
+    releaseSave();
+    await expect(successToast(page)).toBeVisible();
+  });
+
   // @test e2e: Under "External Apps", turning ON "Publish this workspace" enables the other
   //            buttons and when clicking "Save" shows a confirmation and sends the proper API call.
   test('publishing enables app controls, saves, and confirms', async ({ page }) => {
@@ -231,7 +276,7 @@ test.describe('workspace settings', () => {
     await page.route('**/workspaces/1/imagery/settings', route =>
       route.fulfill({ json: emptyImagerySettings })
     );
-    await page.route('**/imagery-schema.json', route =>
+    await page.route(/(?:imagery-schema|schema)\.json$/, route =>
       route.fulfill({ json: imagerySchema })
     );
 
@@ -261,13 +306,18 @@ test.describe('workspace settings', () => {
     await stubSettings(page);
 
     let imageryPatch: unknown = null;
-    await page.route('**/workspaces/1/imagery/settings', (route) => {
+    let releaseImagerySave: () => void = () => {};
+    const imagerySaveGate = new Promise<void>((resolve) => {
+      releaseImagerySave = resolve;
+    });
+    await page.route('**/workspaces/1/imagery/settings', async (route) => {
       const req = route.request();
       if (req.method() === 'GET') {
         return route.fulfill({ json: emptyImagerySettings });
       }
       if (req.method() === 'PATCH') {
         imageryPatch = JSON.parse(req.postData() ?? '{}');
+        await imagerySaveGate;
         return route.fulfill({ status: 204, body: '' });
       }
       return route.fallback();
@@ -279,6 +329,8 @@ test.describe('workspace settings', () => {
     await imagery.getByLabel('Imagery JSON Definition').fill(JSON.stringify(validImageryDef));
     await imagery.getByRole('button', { name: 'Save' }).click();
 
+    await expect(imagery.getByRole('button', { name: /Saving/ })).toBeDisabled();
+    releaseImagerySave();
     // Outline: a toast is shown when validation passes and the save succeeds.
     await expect(successToast(page)).toBeVisible();
     // Proper API call: PATCH imagery/settings with the parsed definition array.
@@ -293,9 +345,14 @@ test.describe('workspace settings', () => {
     await stubSettings(page);
 
     let deleteCalled = false;
-    await page.route('**/workspaces/1', (route) => {
+    let releaseDelete: () => void = () => {};
+    const deleteGate = new Promise<void>((resolve) => {
+      releaseDelete = resolve;
+    });
+    await page.route('**/workspaces/1', async (route) => {
       if (route.request().method() === 'DELETE') {
         deleteCalled = true;
+        await deleteGate;
         return route.fulfill({ status: 204, body: '' });
       }
       return route.fallback();
@@ -313,6 +370,8 @@ test.describe('workspace settings', () => {
     await confirmField.fill('delete');
     await del.getByRole('button', { name: 'Delete this workspace', exact: true }).click();
 
+    await expect(del.getByRole('button', { name: /Deleting/ })).toBeDisabled();
+    releaseDelete();
     await expect.poll(() => deleteCalled).toBe(true);
     await expect(page).toHaveURL(/\/dashboard$/);
   });

--- a/test/e2e/settings.spec.ts
+++ b/test/e2e/settings.spec.ts
@@ -136,6 +136,7 @@ test.describe('workspace settings', () => {
     await general.getByRole('button', { name: 'Rename' }).click();
 
     await expect(general.getByRole('button', { name: /Renaming/ })).toBeDisabled();
+    await expect(titleField).toBeDisabled();
     releaseRename();
     await expect(successToast(page)).toBeVisible();
     await expect(successToast(page)).toContainText('Workspace renamed successfully.');
@@ -332,6 +333,7 @@ test.describe('workspace settings', () => {
     await imagery.getByRole('button', { name: 'Save' }).click();
 
     await expect(imagery.getByRole('button', { name: /Saving/ })).toBeDisabled();
+    await expect(imagery.getByLabel('Imagery JSON Definition')).toBeDisabled();
     releaseImagerySave();
     // Outline: a toast is shown when validation passes and the save succeeds.
     await expect(successToast(page)).toBeVisible();

--- a/test/e2e/settings.spec.ts
+++ b/test/e2e/settings.spec.ts
@@ -238,6 +238,7 @@ test.describe('workspace settings', () => {
       return route.fallback();
     });
 
+    const c = recordContract(page);
     await page.goto('/workspace/1/settings');
 
     const apps = page.locator('form.card', { hasText: 'External Apps' });
@@ -248,6 +249,7 @@ test.describe('workspace settings', () => {
 
     releaseSave();
     await expect(successToast(page)).toBeVisible();
+    await expect.poll(() => c.violations()).toEqual([]);
   });
 
   // @test e2e: Under "External Apps", turning ON "Publish this workspace" enables the other

--- a/types/tdei.ts
+++ b/types/tdei.ts
@@ -131,6 +131,7 @@ export interface TdeiDatasetSummary {
   id: string;
   name: string;
   version?: string;
+  projectGroupName?: string;
 }
 
 export interface TdeiUserItem {


### PR DESCRIPTION
### DevBoard Tasks

https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3346/
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/4064/
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/4118

#### Dataset picker and TDEI creation

- Replaced the basic dataset input/select with a searchable combobox.
- Added debounced dataset searching, request cancellation, loading indicators, result counts, empty/error states, and keyboard navigation.
- Added accessibility support through listbox roles, active-option tracking, live status announcements, and required/disabled attributes.
- Dataset results now include the source project group and preserve the selected dataset label.
- Updated dataset requests to return all accessible datasets, ordered by most recently uploaded, with pagination and `status=All`.
- Added safe fallbacks when dataset metadata or versions are missing.
- Updated TDEI workspace creation to support selecting datasets independently of the destination project group.

#### Workspace settings

- Added loading states and duplicate-submission protection for workspace rename, External Apps, Custom Imagery, and workspace deletion.
- External Apps publish and quest controls are disabled while saving.
- JSON and URL quest settings retain their existing validation and normalization behavior.
- Custom Imagery validation now participates in the guarded save flow.
- Workspace deletion now validates the attestation in the handler, reports API failures through a toast, and keeps its loading state active until dashboard navigation completes.

#### Additional UI updates

- Adjusted the selected dashboard workspace card’s sticky positioning.
- Expanded E2E coverage for dataset-picker accessibility/filtering and settings loading states.

### Areas impacted for testing

- TDEI dataset searching, selection, keyboard navigation, and source project-group display.
- TDEI workspace creation using datasets from different accessible project groups.
- Dataset responses with missing metadata or versions.
- Workspace rename loading, success, and failure states.
- External Apps publishing and quest JSON/URL configuration.
- Custom Imagery validation and saving.
- Workspace deletion, failure handling, and dashboard redirection.
- Selected workspace card behavior while scrolling the dashboard.

<img width="1470" height="956" alt="Screenshot 2026-08-06 at 1 43 17 PM" src="https://github.com/user-attachments/assets/c4aa0d5a-2db4-4cad-be66-3543f592e730" />
<img width="1470" height="956" alt="Screenshot 2026-08-06 at 1 43 25 PM" src="https://github.com/user-attachments/assets/226f1f7a-9a3c-49f3-8c5d-cbdbf3a9d3aa" />
<img width="1470" height="830" alt="Screenshot 2026-08-06 at 1 45 52 PM" src="https://github.com/user-attachments/assets/ea38e6cd-9fc6-4d4a-a023-74636165656c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced the project-group-scoped dataset select with an accessible, searchable combobox.
- Added debounced search, pagination, keyboard navigation, request cancellation, loading and error states, result counts, and source project-group details.
- Updated TDEI dataset retrieval to return all accessible datasets with `status=All`, sorted by recent upload.
- Added safe fallbacks for missing dataset metadata.
- Kept the workspace project group independent from the selected TDEI dataset.
- Added duplicate-submission protection and loading states for workspace rename, External Apps, Custom Imagery, and deletion.
- Added deletion attestation validation and error toasts.
- Adjusted selected workspace-card sticky positioning.
- Expanded E2E coverage for dataset-picker accessibility and workspace-settings loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->