### PR TITLE
Task 4086: Set changeset hashtags in Rapid manager

### DIFF
--- a/components/review/Details.vue
+++ b/components/review/Details.vue
@@ -38,6 +38,7 @@ const getChangesetMetadata = (changeset: OsmChangeset) => ({
   'Editor': changeset.tags?.created_by,
   'Source': changeset.tags?.source,
   'Imagery': changeset.tags?.imagery_used,
+  'Hashtags': changeset.tags?.hashtags,
   'Review Status': changeset.tags?.reviewed_by
     ? `Reviewed by ${changeset.tags.reviewed_by}`
     : changeset.tags?.review_requested === 'yes'

--- a/pages/workspace/[id]/projects/[projectId]/tasks/[taskId]/editor.vue
+++ b/pages/workspace/[id]/projects/[projectId]/tasks/[taskId]/editor.vue
@@ -427,9 +427,10 @@ function generateInitialHash() {
   const dataUrl = boundaryUrl;
   const customImagerySource = project.customImagery || null;
   if (customImagerySource) {
-    return `#map=${zoom}/${lat}/${lon}&data=${dataUrl}&background=${customImagerySource.id}&hashtags=${encodeURIComponent(changesetTag)}`;
+    return `#map=${zoom}/${lat}/${lon}&data=${dataUrl}&background=${customImagerySource.id}`;
   }
-  return `#map=${zoom}/${lat}/${lon}&data=${dataUrl}&hashtags=${encodeURIComponent(changesetTag)}`;
+
+  return `#map=${zoom}/${lat}/${lon}&data=${dataUrl}`;
 }
 
 function syncTaskHash() {

--- a/pages/workspace/[id]/projects/[projectId]/tasks/[taskId]/editor.vue
+++ b/pages/workspace/[id]/projects/[projectId]/tasks/[taskId]/editor.vue
@@ -85,6 +85,7 @@ const [project, task] = await Promise.all([
   loadProjectDetail(),
   loadTaskDetail(),
 ]);
+const changesetTag = `#tm-${projectId}-${task.taskNumber}`;
 
 const {
   buildFeedbackPayload,
@@ -222,7 +223,7 @@ onMounted(() => {
 
   editorContainer.value.appendChild(manager.containerNode);
   editorLoadErrorMessage.value = '';
-  void manager.switchWorkspace(workspaceId, project.customImagery)
+  void manager.switchWorkspace(workspaceId, project.customImagery, changesetTag)
     .catch(error => handleEditorLoadFailure('switch', error));
 });
 
@@ -426,9 +427,9 @@ function generateInitialHash() {
   const dataUrl = boundaryUrl;
   const customImagerySource = project.customImagery || null;
   if (customImagerySource) {
-    return `#map=${zoom}/${lat}/${lon}&data=${dataUrl}&background=${customImagerySource.id}`;
+    return `#map=${zoom}/${lat}/${lon}&data=${dataUrl}&background=${customImagerySource.id}&hashtags=${encodeURIComponent(changesetTag)}`;
   }
-  return `#map=${zoom}/${lat}/${lon}&data=${dataUrl}`;
+  return `#map=${zoom}/${lat}/${lon}&data=${dataUrl}&hashtags=${encodeURIComponent(changesetTag)}`;
 }
 
 function syncTaskHash() {
@@ -447,7 +448,7 @@ async function mountEditor() {
   }
 
   editorContainer.value.appendChild(manager.containerNode);
-  await manager.init(workspaceId, project.customImagery);
+  await manager.init(workspaceId, project.customImagery, changesetTag);
 }
 
 function handleEditorLoadFailure(action: 'initialize' | 'switch', error: unknown) {

--- a/services/rapid.ts
+++ b/services/rapid.ts
@@ -85,10 +85,12 @@ export class RapidManager {
   async init(
     workspaceId: number,
     customImagerySource: ImagerySource | null = null,
+    changesetHashtags?: string,
   ) {
     this.rapidContext.workspaceId = workspaceId;
     this.rapidContext.tdeiAuth = this.#tdeiAuth;
     this.rapidContext.preauth = { url: this.#osmUrl, apiUrl: this.#osmUrl };
+    this.#setInitialChangesetHashtags(changesetHashtags);
     const initPromise = this.rapidContext.initAsync();
     this.#patchRapidAuth();
     await initPromise;
@@ -116,9 +118,11 @@ export class RapidManager {
 
   async switchWorkspace(
     workspaceId: number,
-    customImagerySource: ImagerySource | null = null
+    customImagerySource: ImagerySource | null = null,
+    changesetHashtags?: string,
   ) {
     this.rapidContext.workspaceId = workspaceId;
+    this.#setInitialChangesetHashtags(changesetHashtags);
 
     // Induce the editor to re-read the configuration from the URL hash:
     window.dispatchEvent(new HashChangeEvent('hashchange', {
@@ -128,6 +132,21 @@ export class RapidManager {
 
     await this.rapidContext.resetAsync();
     this.#addCustomImagerySource(customImagerySource);
+  }
+
+  #setInitialChangesetHashtags(changesetHashtags?: string) {
+    const initialHashParams = this.rapidContext.systems.urlhash?.initialHashParams
+      ?? this.rapidContext.initialHashParams;
+
+    if (!initialHashParams) {
+      return;
+    }
+
+    if (changesetHashtags) {
+      initialHashParams.set('hashtags', changesetHashtags);
+    } else {
+      initialHashParams.delete('hashtags');
+    }
   }
 
   #onLoaded() {

--- a/services/rapid.ts
+++ b/services/rapid.ts
@@ -6,6 +6,17 @@ import { convertToRapidImagerySource } from '~/util/rapid-imagery';
 /** Global `Rapid` namespace injected by the Rapid script at runtime. */
 declare const Rapid: any;
 
+type RapidInitialHashParams = Pick<Map<string, string>, 'delete' | 'set'>;
+
+function isRapidInitialHashParams(value: unknown): value is RapidInitialHashParams {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.delete === 'function' && typeof candidate.set === 'function';
+}
+
 export class RapidManager {
   #baseUrl: string;
   #osmUrl: string;
@@ -86,7 +97,7 @@ export class RapidManager {
     workspaceId: number,
     customImagerySource: ImagerySource | null = null,
     changesetHashtags?: string,
-  ) {
+  ): Promise<void> {
     this.rapidContext.workspaceId = workspaceId;
     this.rapidContext.tdeiAuth = this.#tdeiAuth;
     this.rapidContext.preauth = { url: this.#osmUrl, apiUrl: this.#osmUrl };
@@ -120,7 +131,7 @@ export class RapidManager {
     workspaceId: number,
     customImagerySource: ImagerySource | null = null,
     changesetHashtags?: string,
-  ) {
+  ): Promise<void> {
     this.rapidContext.workspaceId = workspaceId;
     this.#setInitialChangesetHashtags(changesetHashtags);
 
@@ -134,11 +145,11 @@ export class RapidManager {
     this.#addCustomImagerySource(customImagerySource);
   }
 
-  #setInitialChangesetHashtags(changesetHashtags?: string) {
-    const initialHashParams = this.rapidContext.systems.urlhash?.initialHashParams
+  #setInitialChangesetHashtags(changesetHashtags?: string): void {
+    const initialHashParams: unknown = this.rapidContext.systems?.urlhash?.initialHashParams
       ?? this.rapidContext.initialHashParams;
 
-    if (!initialHashParams) {
+    if (!isRapidInitialHashParams(initialHashParams)) {
       return;
     }
 

--- a/test/e2e/edit.spec.ts
+++ b/test/e2e/edit.spec.ts
@@ -40,6 +40,14 @@ const RAPID2_SCRIPT = (route: Route) => route.fulfill({
             '<div class="fake-editor" role="application" aria-label="Rapid 2 editor">Rapid 2 editor</div>';
         }
         services = { osm: { _oauth: { fetch: () => {}, authenticated: () => true }, userDetails: () => {} } };
+        systems = {
+          urlhash: { initialHashParams: new Map() },
+          editor: {
+            changes: () => ({ created: [], deleted: [], modified: [] }),
+            on: () => {}
+          },
+          uploader: { on: () => {} }
+        };
       }
     };
   `

--- a/test/unit/services/rapid.test.ts
+++ b/test/unit/services/rapid.test.ts
@@ -14,6 +14,7 @@ describe('RapidManager subscriptions', () => {
     );
     manager.rapidContext = {
       initAsync: vi.fn().mockResolvedValue(undefined),
+      resetAsync: vi.fn().mockResolvedValue(undefined),
       services: {
         osm: {
           _oauth: {
@@ -24,6 +25,9 @@ describe('RapidManager subscriptions', () => {
         },
       },
       systems: {
+        urlhash: {
+          initialHashParams: new Map<string, string>(),
+        },
         editor: {
           changes: () => ({ created: [], deleted: [], modified: [{}] }),
           on: (_event: string, handler: () => void) => {
@@ -57,5 +61,45 @@ describe('RapidManager subscriptions', () => {
 
     expect(stateCallback).toHaveBeenCalledOnce();
     expect(uploadCallback).toHaveBeenCalledOnce();
+  });
+
+  it('replaces the initial changeset hashtag when initializing another task', async () => {
+    const initialHashParams = new Map<string, string>([
+      ['hashtags', '#tm-39-1'],
+    ]);
+    const manager = new RapidManager(
+      '/rapid/',
+      'https://www.openstreetmap.org/',
+      { ok: true } as TdeiAuthStore,
+    );
+    manager.rapidContext = {
+      initAsync: vi.fn().mockResolvedValue(undefined),
+      resetAsync: vi.fn().mockResolvedValue(undefined),
+      services: {
+        osm: {
+          _oauth: {
+            authenticated: vi.fn(),
+            fetch: vi.fn(),
+          },
+          userDetails: vi.fn(),
+        },
+      },
+      systems: {
+        urlhash: { initialHashParams },
+        editor: {
+          changes: () => ({ created: [], deleted: [], modified: [] }),
+          on: vi.fn(),
+        },
+        uploader: { on: vi.fn() },
+      },
+    };
+
+    await manager.init(1763, null, '#tm-39-2');
+
+    expect(initialHashParams.get('hashtags')).toBe('#tm-39-2');
+
+    await manager.switchWorkspace(1763, null, '#tm-39-3');
+
+    expect(initialHashParams.get('hashtags')).toBe('#tm-39-3');
   });
 });


### PR DESCRIPTION
# DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/4086/

## Changes implemented

- Added a prefilled Rapid changeset hashtag for Tasking Editor sessions:
  - Format: `#tm-{projectId}-{taskNumber}`
  - Example: `#tm-39-2`
- Passes the hashtag through Rapid’s supported `hashtags` URL parameter on initial load.
- Updates Rapid’s internal initial hash parameters when switching tasks, preventing the previous task’s hashtag from being reused.
- Reconstructs the hashtag from the current project/task after a page refresh.
- Added unit coverage for initial tag population and task switching.

## Impacted areas for testing

- Open a task in the Tasking Editor and confirm the expected hashtag appears in Rapid’s changeset form.
- Submit a changeset and confirm its `hashtags` tag contains the expected value.
- Switch to another task and confirm the hashtag uses the new task number rather than the previous one.
- Refresh the Tasking Editor page and confirm the correct hashtag remains prefilled.
- Test projects and tasks with different IDs to verify the format.
- Open the regular workspace editor and confirm task-specific hashtag behavior is not introduced there.
- Confirm custom imagery and task boundary loading still work.
- Confirm changeset submission and task completion continue working.

### Manual verification

Verified the Rapid `changeset/create` request payload for project `45`, task `127`.

```xml
<tag k="hashtags" v="#tm-45-127"/>
```
### Screenshots
<img width="1470" height="956" alt="Screenshot 2026-08-10 at 12 23 57 PM" src="https://github.com/user-attachments/assets/8a994833-a059-482b-b1a6-bc80d6a54658" />
<img width="1470" height="838" alt="Screenshot 2026-08-10 at 4 47 51 PM" src="https://github.com/user-attachments/assets/07a87033-37b7-4f6d-8b1e-d6553257a4c7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Add task-specific Rapid changeset hashtags in the format `#tm-{projectId}-{taskNumber}`.
- Pass hashtags through Rapid’s `hashtags` URL parameter during initialization and task switching.
- Restore the hashtag after page refreshes.
- Validate Rapid’s `initialHashParams` before use.
- Remove `hashtags` from generated map hashes while retaining Rapid’s initial hashtag parameters.
- Update Rapid mocks and add unit tests for hashtag replacement during initialization and workspace switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->