### PR TITLE
Bugfix 3911 review loader zero changesets

### DIFF
--- a/components/review/Map.vue
+++ b/components/review/Map.vue
@@ -136,11 +136,12 @@ let drawGeneration = 0;
 async function drawItem(item: ReviewListItem | undefined) {
   emptyChangeset.value = false;
   mapError.value = null;
+  const generation = ++drawGeneration;
   if (!item) {
+    loading.value = false;
     return;
   }
 
-  const generation = ++drawGeneration;
   loading.value = true;
   try {
     if (item.isChangeset) {

--- a/components/review/Map.vue
+++ b/components/review/Map.vue
@@ -82,6 +82,9 @@ let reviewMap: maplibregl.Map;
 let adiffViewer: typeof MapLibreAugmentedDiffViewer;
 let popup: maplibregl.Popup;
 let resizeObserver: ResizeObserver | undefined;
+const emptyChangeset = defineModel<boolean>('emptyChangeset', {
+  default: false
+});
 
 onMounted(() => {
   initMap();
@@ -126,32 +129,44 @@ function getLatLonZoom() {
 }
 
 async function drawItem(item: ReviewListItem | undefined) {
+  emptyChangeset.value = false;
   if (!item) {
     return;
   }
 
   loading.value = true;
+  try {
+    if (item.isChangeset) {
+      if (item.loadingChangeset) {
+        await item.oscPromise;
+      }
 
-  if (item.isChangeset) {
-    if (item.loadingChangeset) {
-      await item.oscPromise;
+      await drawChangeset(item.data as OsmChangeset);
     }
-
-    await drawChangeset(item.data as OsmChangeset);
+    else if (item.isFeedback) {
+      drawFeedback(item.data as TdeiFeedback);
+    }
+    else if (item.isNote) {
+      drawNote(item.data as OsmNote);
+    }
   }
-  else if (item.isFeedback) {
-    drawFeedback(item.data as TdeiFeedback);
+  finally {
+    loading.value = false;
   }
-  else if (item.isNote) {
-    drawNote(item.data as OsmNote);
-  }
-
-  loading.value = false;
 }
 
 async function drawChangeset(changeset: OsmChangeset) {
   const adiff = await changesetManager.getAdiff(props.workspaceId, changeset);
   resetMap();
+  const hasChanges = adiff.actions.some(action =>
+    action.type === 'create'
+    || action.type === 'modify'
+    || action.type === 'delete'
+  );
+  if (!hasChanges) {
+    emptyChangeset.value = true;
+    return;
+  }
 
   adiffViewer = new MapLibreAugmentedDiffViewer(adiff, {
     onClick: onAdiffClick,

--- a/components/review/Map.vue
+++ b/components/review/Map.vue
@@ -85,6 +85,9 @@ let resizeObserver: ResizeObserver | undefined;
 const emptyChangeset = defineModel<boolean>('emptyChangeset', {
   default: false
 });
+const mapError = defineModel<string | null>('mapError', {
+  default: null
+});
 
 onMounted(() => {
   initMap();
@@ -128,12 +131,16 @@ function getLatLonZoom() {
   return { lat, lon: lng, zoom };
 }
 
+let drawGeneration = 0;
+
 async function drawItem(item: ReviewListItem | undefined) {
   emptyChangeset.value = false;
+  mapError.value = null;
   if (!item) {
     return;
   }
 
+  const generation = ++drawGeneration;
   loading.value = true;
   try {
     if (item.isChangeset) {
@@ -141,22 +148,36 @@ async function drawItem(item: ReviewListItem | undefined) {
         await item.oscPromise;
       }
 
-      await drawChangeset(item.data as OsmChangeset);
+      await drawChangeset(item.data as OsmChangeset, generation);
     }
     else if (item.isFeedback) {
-      drawFeedback(item.data as TdeiFeedback);
+      if (generation === drawGeneration) drawFeedback(item.data as TdeiFeedback);
     }
     else if (item.isNote) {
-      drawNote(item.data as OsmNote);
+      if (generation === drawGeneration) drawNote(item.data as OsmNote);
+    }
+  }
+  catch {
+    // Discard result if the user already selected a different changeset.
+    if (generation === drawGeneration) {
+      mapError.value = 'Could not load changeset data. The server may be unavailable or took too long to respond. Try again or select a different changeset.';
     }
   }
   finally {
-    loading.value = false;
+    if (generation === drawGeneration) {
+      loading.value = false;
+    }
   }
 }
 
-async function drawChangeset(changeset: OsmChangeset) {
+async function drawChangeset(changeset: OsmChangeset, generation: number) {
   const adiff = await changesetManager.getAdiff(props.workspaceId, changeset);
+
+  // Discard result if the user already selected a different changeset.
+  if (generation !== drawGeneration) {
+    return;
+  }
+
   resetMap();
   const hasChanges = adiff.actions.some(action =>
     action.type === 'create'

--- a/components/review/Sidebar.vue
+++ b/components/review/Sidebar.vue
@@ -29,6 +29,12 @@
       class="list-group"
     >
       <app-spinner v-if="loading" />
+      <p
+        v-else-if="!items.length"
+        class="review-sidebar-empty"
+      >
+        No items to review.
+      </p>
       <review-item
         v-for="item in items"
         :key="item.key"
@@ -142,6 +148,14 @@ function refresh() {
       right: 0;
       margin: 0 auto;
     }
+  }
+
+  .review-sidebar-empty {
+    padding: 1.5rem 1rem;
+    margin: 0;
+    color: var(--bs-secondary-color);
+    font-size: 0.875rem;
+    text-align: center;
   }
 
   .list-group-item:first-child {

--- a/pages/workspace/[id]/review.vue
+++ b/pages/workspace/[id]/review.vue
@@ -25,11 +25,12 @@
       <review-map
         ref="map"
         v-model:loading="loadingMap"
+        v-model:empty-changeset="emptyChangeset"
         v-model:current-diff="currentDiff"
         :workspace-id="workspaceId"
         :item="currentItem"
       />
-
+      v-model:current-diff="currentDiff" :workspace-id="workspaceId" :item="currentItem" />
       <transition name="fade">
         <div
           v-show="loadingMap"
@@ -38,12 +39,16 @@
           <app-spinner size="lg" />
         </div>
       </transition>
+
       <transition name="fade">
         <div
-          v-show="!currentItem"
+          v-show="emptyChangeset && !loadingMap"
           class="review-notice"
+          role="status"
         >
-          <!-- TODO: add some content/help here -->
+          <p class="d-flex h-100 align-items-center justify-content-center mb-0">
+            This changeset contains no changes.
+          </p>
         </div>
       </transition>
 
@@ -100,6 +105,7 @@ const imageViewer = useTemplateRef<InstanceType<typeof AppImageViewer>>('imageVi
 
 const loading = ref(false);
 const loadingMap = ref(false);
+const emptyChangeset = ref(false);
 const currentItem = ref<ReviewListItem | undefined>();
 const currentDiff = ref<AdiffAction | undefined>();
 

--- a/pages/workspace/[id]/review.vue
+++ b/pages/workspace/[id]/review.vue
@@ -26,11 +26,11 @@
         ref="map"
         v-model:loading="loadingMap"
         v-model:empty-changeset="emptyChangeset"
+        v-model:map-error="mapError"
         v-model:current-diff="currentDiff"
         :workspace-id="workspaceId"
         :item="currentItem"
       />
-      v-model:current-diff="currentDiff" :workspace-id="workspaceId" :item="currentItem" />
       <transition name="fade">
         <div
           v-show="loadingMap"
@@ -48,6 +48,18 @@
         >
           <p class="d-flex h-100 align-items-center justify-content-center mb-0">
             This changeset contains no changes.
+          </p>
+        </div>
+      </transition>
+
+      <transition name="fade">
+        <div
+          v-show="mapError && !loadingMap"
+          class="review-notice review-notice-error"
+          role="alert"
+        >
+          <p class="d-flex h-100 align-items-center justify-content-center mb-0 text-center px-3">
+            {{ mapError }}
           </p>
         </div>
       </transition>
@@ -106,6 +118,7 @@ const imageViewer = useTemplateRef<InstanceType<typeof AppImageViewer>>('imageVi
 const loading = ref(false);
 const loadingMap = ref(false);
 const emptyChangeset = ref(false);
+const mapError = ref<string | null>(null);
 const currentItem = ref<ReviewListItem | undefined>();
 const currentDiff = ref<AdiffAction | undefined>();
 
@@ -208,6 +221,11 @@ async function openEditor() {
 
   .review-notice {
     background-color: var(--bs-body-bg);
+  }
+
+  .review-notice-error {
+    background-color: var(--bs-body-bg);
+    color: $danger-red;
   }
 
   @include media-breakpoint-down(md) {


### PR DESCRIPTION
## DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3911/

**Changes Implemented**

- Wrap `drawItem()` in `try/finally` so the loading spinner always clears, even when the adiff fetch fails or returns early
- Show "This changeset contains no changes." when a changeset has 0 diffs
- Show an error message when the adiff fetch fails (504, timeout, etc.)
- Silently ignore errors from superseded requests (user clicks a different changeset mid-load)
- Show "No items to review." in the sidebar when all three lists (changesets, feedback, notes) return empty

**Impacted Areas to Test**

- Review page : 
  - changeset with changes → map draws normally
  - changeset with 0 changes (0|0|0 badge) → "no changes" notice appears, no infinite spinner
  - adiff call returns 504/timeout → error message appears, spinner clears
  - click changeset A, quickly click changeset B before A loads → no error shown, B loads cleanly
  - workspace with no changesets, no feedback, no notes → "No items to review." shown in sidebar
  - refresh button → same empty-state behaviour applies after refresh

### Screenshots
<img width="1470" height="877" alt="Screenshot 2026-08-19 at 5 27 13 PM" src="https://github.com/user-attachments/assets/8e264630-260a-4480-854f-63664530877f" />
<img width="1470" height="881" alt="Screenshot 2026-08-19 at 6 22 46 PM" src="https://github.com/user-attachments/assets/a405da7f-4da8-4b1a-a2e0-0104fb4d40d9" />
<img width="1470" height="873" alt="Screenshot 2026-08-19 at 6 29 38 PM" src="https://github.com/user-attachments/assets/4f20d6ae-1359-404f-bb3a-576ee61168cc" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added concurrency-safe map loading with stale request cancellation.
- Cleared the loading state when adiff requests fail or return early.
- Added error handling for failed changeset data requests.
- Added empty-state messages for zero-diff changesets and empty review lists.
- Preserved empty states after refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->