### PR TITLE
Fix headers race in early Rapid requests

### DIFF
--- a/services/rapid.ts
+++ b/services/rapid.ts
@@ -102,6 +102,12 @@ export class RapidManager {
     this.rapidContext.tdeiAuth = this.#tdeiAuth;
     this.rapidContext.preauth = { url: this.#osmUrl, apiUrl: this.#osmUrl };
     this.#setInitialChangesetHashtags(changesetHashtags);
+
+    // The initAsync() call inits services synchronously before returning its
+    // promise, so services.osm._oauth exists as soon as initAsync() returns.
+    // Patching before await ensures all requests during the async init chain
+    // (especially loadTiles) include workspace headers:
+    //
     const initPromise = this.rapidContext.initAsync();
     this.#patchRapidAuth();
     await initPromise;


### PR DESCRIPTION
This prevents a race condition that occurs when opening Rapid at a high enough zoom level to load tiles upon startup. The initial tile requests fail because they don't include an `X-Workspace` header&mdash;the Rapid service wraps the client to inject those headers after Rapid already requested the tiles.