### PR TITLE
Table format to match -backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,23 +78,11 @@ jobs:
         if: ${{ !cancelled() && hashFiles('coverage/coverage-final.json') != '' }}
         run: npm run coverage:combine
 
-      # Print the combined unit+e2e totals to this step's log AND the GitHub run
-      # summary UI.
+      # Print a per-file coverage table (Stmts/Miss/Cover + TOTAL) to this step's
+      # log AND the GitHub run summary UI.
       - name: Coverage summary
         if: ${{ !cancelled() && hashFiles('coverage/combined/coverage-summary.json') != '' }}
-        run: |
-          node -e '
-            const t = require("./coverage/combined/coverage-summary.json").total;
-            const keys = ["lines","statements","functions","branches"];
-            // Printed to the step log so the number is visible in the CI output.
-            console.log("Combined coverage (unit + e2e):");
-            keys.forEach(k => console.log(`  ${(k[0].toUpperCase()+k.slice(1)).padEnd(11)} ${String(t[k].pct+"%").padStart(7)}  (${t[k].covered}/${t[k].total})`));
-            const rows = keys
-              .map(k => `| ${k[0].toUpperCase()+k.slice(1)} | ${t[k].pct}% | ${t[k].covered}/${t[k].total} |`)
-              .join("\n");
-            const md = `## Test coverage — unit + e2e (combined)\n\n| Metric | % | Covered |\n| --- | --- | --- |\n${rows}\n`;
-            require("fs").appendFileSync(process.env.GITHUB_STEP_SUMMARY, md);
-          '
+        run: node scripts/coverage-report.mjs
 
       # Browsable combined HTML report (open index.html from the artifact).
       - name: Upload coverage report

--- a/scripts/coverage-report.mjs
+++ b/scripts/coverage-report.mjs
@@ -1,0 +1,54 @@
+// Prints a per-file coverage table (coverage.py / pytest-cov style) from the
+// combined unit+e2e report. Writes an aligned text table to stdout (visible in
+// the CI step log) and a markdown table to the GitHub run summary when
+// GITHUB_STEP_SUMMARY is set. Cover is statement coverage, rounded to whole
+// percent; Miss = statements - covered.
+import { readFileSync, appendFileSync } from 'node:fs';
+import { relative } from 'node:path';
+
+const SUMMARY = 'coverage/combined/coverage-summary.json';
+
+const data = JSON.parse(readFileSync(SUMMARY, 'utf8'));
+const cwd = process.cwd();
+
+const toRow = (name, s) => ({
+  name,
+  stmts: s.total,
+  miss: s.total - s.covered,
+  cover: Math.round(s.pct)
+});
+
+const files = Object.entries(data)
+  .filter(([k]) => k !== 'total')
+  .map(([abs, m]) => toRow(relative(cwd, abs), m.statements))
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+const totalRow = toRow('TOTAL', data.total.statements);
+
+// --- aligned text table for the step log ---
+const all = [{ name: 'Name', stmts: 'Stmts', miss: 'Miss', cover: 'Cover' }, ...files, totalRow];
+const w = key => Math.max(...all.map(r => String(r[key]).length + (key === 'cover' && r.cover !== 'Cover' ? 1 : 0)));
+const nameW = w('name');
+const cols = { stmts: w('stmts'), miss: w('miss'), cover: w('cover') };
+const pct = v => (typeof v === 'number' ? `${v}%` : v);
+const line = r =>
+  `${String(r.name).padEnd(nameW)}  ${String(r.stmts).padStart(cols.stmts)}  ${String(r.miss).padStart(cols.miss)}  ${pct(r.cover).padStart(cols.cover)}`;
+
+console.log(`Test coverage — ${totalRow.cover}%`);
+console.log(line({ name: 'Name', stmts: 'Stmts', miss: 'Miss', cover: 'Cover' }));
+for (const r of files) console.log(line(r));
+console.log(line(totalRow));
+
+// --- markdown table for the GitHub run summary ---
+if (process.env.GITHUB_STEP_SUMMARY) {
+  const md = [
+    `## Test coverage — ${totalRow.cover}%`,
+    '',
+    '| Name | Stmts | Miss | Cover |',
+    '| --- | ---: | ---: | ---: |',
+    ...files.map(r => `| ${r.name} | ${r.stmts} | ${r.miss} | ${r.cover}% |`),
+    `| **TOTAL** | ${totalRow.stmts} | ${totalRow.miss} | ${totalRow.cover}% |`,
+    ''
+  ].join('\n');
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, md);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Moved coverage report generation from an inline CI script to `scripts/coverage-report.mjs`.
- Added per-file and total statement coverage calculations.
- Added sorted, aligned coverage output.
- Added conditional Markdown table output to the GitHub Actions step summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->