### PR TITLE
Bugfix 4085: Prevent project creator role override and improve imagery error visibility in project edit

### DIFF
--- a/composables/useProjectWizardSettings.ts
+++ b/composables/useProjectWizardSettings.ts
@@ -59,7 +59,7 @@ export function useProjectWizardSettings(options: UseProjectWizardSettingsOption
         return false;
       }
 
-      // Exclude the current user from assignable list 
+      // Exclude the current user from assignable list
       // Backend automatically assigns the project creator as lead.
       if (options.currentUserId && user.authUid === options.currentUserId) {
         return false;
@@ -94,11 +94,11 @@ export function useProjectWizardSettings(options: UseProjectWizardSettingsOption
 
         return matchedUser
           ? {
-            ...assignment,
-            displayName: matchedUser.displayName,
-            email: matchedUser.email,
-            role: PROJECT_WIZARD_VALIDATOR_ROLE,
-          }
+              ...assignment,
+              displayName: matchedUser.displayName,
+              email: matchedUser.email,
+              role: PROJECT_WIZARD_VALIDATOR_ROLE,
+            }
           : assignment;
       });
       workspaceUsersLoaded.value = true;

--- a/composables/useProjectWizardSettings.ts
+++ b/composables/useProjectWizardSettings.ts
@@ -11,6 +11,7 @@ import { resolveHttpErrorMessage } from '~/services/http';
 
 interface UseProjectWizardSettingsOptions {
   currentStep: Ref<ProjectWizardStepId>;
+  currentUserId: string | null;
   draft: ProjectWizardDraft;
   projectGroupId: string;
 }
@@ -58,6 +59,12 @@ export function useProjectWizardSettings(options: UseProjectWizardSettingsOption
         return false;
       }
 
+      // Exclude the current user from assignable list 
+      // Backend automatically assigns the project creator as lead.
+      if (options.currentUserId && user.authUid === options.currentUserId) {
+        return false;
+      }
+
       if (!normalizedQuery) {
         return true;
       }
@@ -87,11 +94,11 @@ export function useProjectWizardSettings(options: UseProjectWizardSettingsOption
 
         return matchedUser
           ? {
-              ...assignment,
-              displayName: matchedUser.displayName,
-              email: matchedUser.email,
-              role: PROJECT_WIZARD_VALIDATOR_ROLE,
-            }
+            ...assignment,
+            displayName: matchedUser.displayName,
+            email: matchedUser.email,
+            role: PROJECT_WIZARD_VALIDATOR_ROLE,
+          }
           : assignment;
       });
       workspaceUsersLoaded.value = true;

--- a/pages/workspace/[id]/projects/[projectId]/edit.vue
+++ b/pages/workspace/[id]/projects/[projectId]/edit.vue
@@ -1624,7 +1624,9 @@ $project-edit-action-spacing: 30px;
   .project-edit-sidebar-footer {
     padding-top: 1rem;
     position: fixed;
-    bottom: 0px;
+    bottom: 0;
+    left: 0;
+    right: 0;
     width: 100%;
     background: #ffffff;
     z-index: 10;
@@ -1637,7 +1639,7 @@ $project-edit-action-spacing: 30px;
   .project-edit-content-inner {
     max-width: none;
     padding: 1.5rem;
-    margin-bottom: 80px;
+    margin-bottom: 12rem;
   }
 
   .project-edit-settings-row {

--- a/pages/workspace/[id]/projects/[projectId]/edit.vue
+++ b/pages/workspace/[id]/projects/[projectId]/edit.vue
@@ -38,33 +38,51 @@
               @click="openSection(section.id)"
             >
               {{ section.label }}
+              <app-icon
+                v-if="section.id === 'imagery' && imageryError"
+                variant="error"
+                size="16"
+                no-margin
+                class="project-edit-nav-item-error-icon"
+                aria-label="Imagery has an error"
+              />
             </button>
           </nav>
 
           <footer class="project-edit-sidebar-footer">
-            <button
-              class="btn btn-link project-edit-cancel"
-              type="button"
-              :disabled="saving || mutatingMemberId !== null"
-              @click="handleCancel"
+            <p
+              v-if="imageryError"
+              class="project-edit-save-warning"
+              role="alert"
             >
-              Cancel
-            </button>
+              Imagery error is blocking save. Go to the Imagery tab to fix it.
+            </p>
 
-            <button
-              class="btn project-edit-save"
-              type="button"
-              :disabled="!canSave"
-              @click="handleSave"
-            >
-              <app-spinner
-                v-if="saving"
-                size="sm"
-              />
-              <template v-else>
-                Save
-              </template>
-            </button>
+            <div class="project-edit-sidebar-footer-actions">
+              <button
+                class="btn btn-link project-edit-cancel"
+                type="button"
+                :disabled="saving || mutatingMemberId !== null"
+                @click="handleCancel"
+              >
+                Cancel
+              </button>
+
+              <button
+                class="btn project-edit-save"
+                type="button"
+                :disabled="!canSave"
+                @click="handleSave"
+              >
+                <app-spinner
+                  v-if="saving"
+                  size="sm"
+                />
+                <template v-else>
+                  Save
+                </template>
+              </button>
+            </div>
           </footer>
         </aside>
 
@@ -1001,11 +1019,28 @@ $project-edit-action-spacing: 30px;
 .project-edit-sidebar-footer {
   flex-shrink: 0;
   display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: $project-edit-footer-padding;
+  border-top: 1px solid rgba($text-navy, 0.08);
+}
+
+.project-edit-sidebar-footer-actions {
+  display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: $project-edit-footer-padding;
-  border-top: 1px solid rgba($text-navy, 0.08);
+}
+
+.project-edit-save-warning {
+  margin: 0;
+  padding: 0.5rem 0.65rem;
+  color: $danger-red;
+  font-size: 0.82rem;
+  font-weight: 500;
+  background: rgba($danger-red, 0.06);
+  border: 1px solid rgba($danger-red, 0.2);
+  border-radius: 0.4rem;
 }
 
 .project-edit-cancel {

--- a/pages/workspace/[id]/projects/create.vue
+++ b/pages/workspace/[id]/projects/create.vue
@@ -327,6 +327,7 @@ const {
   retryLoadWorkspaceUsers,
 } = useProjectWizardSettings({
   currentStep,
+  currentUserId: projectWizardClient.auth.subject || null,
   draft,
   projectGroupId: workspace.tdeiProjectGroupId,
 });


### PR DESCRIPTION
## DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/4085

### Changes Implemented:

- **Bug fix** -> Project creator adding themselves as a contributor during the wizard now no longer appears in the contributor search results. Prevents their backend-assigned Lead role from being overwritten with Validator
- **UX fix** -> When the Imagery tab has a validation error, a warning message now appears in the edit page sidebar footer explaining it's blocking Save, visible from any tab

**Areas to Test:**

1. **Project creation -> contributor assignment**
   - Search for yourself (logged-in user) in the Settings step contributor search → should not appear in results
   - Complete project creation → verify you appear as **Lead** in the Contributors tab, not Validator/Contributor

2. **Project edit -> imagery error warning**
   - Open a project with invalid custom imagery (or paste invalid JSON in the Imagery tab)
   - Switch to the **Project Details** tab
   - Verify the red warning message appears in the sidebar footer: *"Imagery error is blocking save. Go to the Imagery tab to fix it."*
   - Fix the imagery → verify warning disappears and Save enables

3. **Project edit -> Save/Cancel still work normally**
   - Edit description with no imagery error → Save should work as before
   - Cancel with unsaved changes → discard dialog should still appear
   - No regressions in other tabs (Instructions, Team, Configuration)
   
### Screenshots:
<img width="1470" height="956" alt="Screenshot 2026-08-21 at 3 50 17 PM" src="https://github.com/user-attachments/assets/48a285e2-f722-43f1-8212-57b56fe1dfbb" />
<img width="1470" height="956" alt="Screenshot 2026-08-21 at 4 21 43 PM" src="https://github.com/user-attachments/assets/c4a390af-5c71-4ba7-855f-672ad7b20b03" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Exclude the logged-in project creator from the assignable validator list.
- Show imagery validation errors in the edit sidebar.
- Disable saving while imagery validation fails.
- Add a warning that directs users to the Imagery tab.
- Refactor the sidebar footer layout without changing Save or Cancel behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->