### PR TITLE
Replace OSM tiles with OpenFreeMap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ conventions established for it; see `README.md` for app setup.
 ## Project
 
 - **TDEI Workspaces frontend** — Nuxt 4 / Vue 3 **SPA** (`ssr: false`),
-  bootstrap-vue-next UI, maplibre-gl + Leaflet maps.
+  bootstrap-vue-next UI, maplibre-gl maps.
 - API access is via class-based HTTP clients in `services/` (all extend
   `BaseHttpClient` in [services/http.ts](services/http.ts), which wraps `fetch`).
   Clients are constructed in [services/index.ts](services/index.ts) from

--- a/components/dashboard/Map.vue
+++ b/components/dashboard/Map.vue
@@ -31,7 +31,8 @@
 import { LoadingContext } from '~/services/loading';
 import { workspacesClient } from '~/services/index';
 import { isRecord, parseMetadata } from '~/util/metadata';
-import { OPENFREEMAP_STYLE_URL } from '~/util/map-style';
+import { createMaplibreMap } from '~/util/map-style';
+import { bboxToPolygon, getGeoJsonBounds } from '~/util/geojson';
 
 import type { Workspace, WorkspaceCenter } from '~/types/workspaces';
 
@@ -39,25 +40,20 @@ interface Props {
   workspace: Workspace;
 }
 
-interface LeafletBounds {
-  getCenter: () => { lat: number; lng: number };
-  isValid: () => boolean;
-}
-
-interface LeafletMap {
-  fitBounds: (bounds: LeafletBounds) => void;
-  getBoundsZoom: (bounds: LeafletBounds) => number;
-  invalidateSize: (options?: { animate?: boolean; pan?: boolean }) => void;
-  remove: () => void;
-}
-
-interface LeafletPolygon {
-  addTo: (map: LeafletMap) => void;
-  getBounds: () => LeafletBounds;
-  remove: () => void;
-}
-
 type MapState = 'loading' | 'ready' | 'empty' | 'error';
+type Bounds = [[number, number], [number, number]];
+
+interface WorkspaceArea {
+  geojson: unknown;
+  bounds: Bounds;
+}
+
+const AREA_SOURCE_ID = 'workspace-preview-area';
+const AREA_FILL_ID = 'workspace-preview-area-fill';
+const AREA_LINE_ID = 'workspace-preview-area-line';
+const AREA_COLOR = '#3388ff';
+const AREA_PADDING = 24;
+const emptyCollection = { type: 'FeatureCollection', features: [] };
 
 const props = defineProps<Props>();
 const emit = defineEmits<{
@@ -66,10 +62,12 @@ const emit = defineEmits<{
 
 const loadingBbox = reactive(new LoadingContext());
 const mapElement = ref<HTMLElement | null>(null);
-const map = ref<LeafletMap | null>(null);
-const workspaceAreaPolygon = ref<LeafletPolygon | null>(null);
 const mapState = ref<MapState>('loading');
 
+let maplibregl: typeof import('maplibre-gl') | null = null;
+let map: import('maplibre-gl').Map | null = null;
+let mapReadyPromise: Promise<void> | null = null;
+let currentAreaBounds: Bounds | null = null;
 let mapRequestId = 0;
 let resizeObserver: ResizeObserver | undefined;
 let resizeFrame: number | undefined;
@@ -82,30 +80,64 @@ function resizeMap() {
   resizeFrame = requestAnimationFrame(() => {
     resizeFrame = undefined;
 
-    if (
-      mapState.value !== 'ready'
-      || !map.value
-      || !workspaceAreaPolygon.value
-    ) {
+    if (mapState.value !== 'ready' || !map || !maplibregl || !currentAreaBounds) {
       return;
     }
 
-    const bounds = workspaceAreaPolygon.value.getBounds();
+    map.resize();
 
-    map.value.invalidateSize({
-      animate: false,
-      pan: false
-    });
-    map.value.fitBounds(bounds);
+    const camera = map.cameraForBounds(currentAreaBounds, { padding: AREA_PADDING });
 
-    const zoom = map.value.getBoundsZoom(bounds);
-    const center = bounds.getCenter();
+    if (!camera?.center || camera.zoom === undefined) {
+      return;
+    }
+
+    map.jumpTo(camera);
+
+    const center = maplibregl.LngLat.convert(camera.center);
 
     emit('centerLoaded', {
-      zoom,
+      zoom: camera.zoom,
       latitude: center.lat,
       longitude: center.lng
     });
+  });
+}
+
+// Memoized so concurrent workspace switches share one in-flight init instead
+// of racing to create duplicate maplibregl.Map instances.
+function ensureMap(): Promise<void> {
+  if (!mapReadyPromise) {
+    mapReadyPromise = initMap();
+  }
+
+  return mapReadyPromise;
+}
+
+async function initMap(): Promise<void> {
+  if (!mapElement.value) {
+    return;
+  }
+
+  const handle = await createMaplibreMap(mapElement.value, { center: [0, 0], zoom: 0 });
+
+  maplibregl = handle.maplibregl;
+  map = handle.map;
+
+  await handle.ready;
+
+  map.addSource(AREA_SOURCE_ID, { type: 'geojson', data: emptyCollection as any });
+  map.addLayer({
+    id: AREA_FILL_ID,
+    type: 'fill',
+    source: AREA_SOURCE_ID,
+    paint: { 'fill-color': AREA_COLOR, 'fill-opacity': 0.2 },
+  });
+  map.addLayer({
+    id: AREA_LINE_ID,
+    type: 'line',
+    source: AREA_SOURCE_ID,
+    paint: { 'line-color': AREA_COLOR, 'line-width': 3 },
   });
 }
 
@@ -131,34 +163,20 @@ onBeforeUnmount(() => {
     cancelAnimationFrame(resizeFrame);
   }
 
-  workspaceAreaPolygon.value?.remove();
-  map.value?.remove();
+  map?.remove();
+  map = null;
+  mapReadyPromise = null;
 });
 
-function initMap() {
-  if (!mapElement.value) {
-    return;
-  }
-
-  map.value = L.map(mapElement.value) as LeafletMap;
-
-  L.maplibreGL({ style: OPENFREEMAP_STYLE_URL }).addTo(map.value);
-}
-
-async function getWorkspacePolygon(
-  workspace: Workspace
-): Promise<LeafletPolygon | null> {
+async function getWorkspaceArea(workspace: Workspace): Promise<WorkspaceArea | null> {
   const metadataArea = getMetadataArea(parseMetadata(workspace.tdeiMetadata));
+  const metadataBounds = metadataArea ? getGeoJsonBounds(metadataArea) : null;
 
-  if (metadataArea) {
-    const polygon = L.geoJSON(metadataArea) as LeafletPolygon;
-
-    if (polygon.getBounds().isValid()) {
-      return polygon;
-    }
+  if (metadataArea && metadataBounds) {
+    return { geojson: metadataArea, bounds: metadataBounds };
   }
 
-  let polygon: LeafletPolygon | null = null;
+  let area: WorkspaceArea | null = null;
 
   await loadingBbox.cancelable(workspacesClient, async (client) => {
     const bbox = await client.getWorkspaceBbox(workspace.id);
@@ -167,13 +185,13 @@ async function getWorkspacePolygon(
       return;
     }
 
-    polygon = L.rectangle([
-      [bbox.min_lat, bbox.min_lon],
-      [bbox.max_lat, bbox.max_lon]
-    ]) as LeafletPolygon;
+    area = {
+      geojson: bboxToPolygon(bbox.min_lat, bbox.min_lon, bbox.max_lat, bbox.max_lon),
+      bounds: [[bbox.min_lon, bbox.min_lat], [bbox.max_lon, bbox.max_lat]],
+    };
   });
 
-  return polygon;
+  return area;
 }
 
 async function updateMapPreview(workspace: Workspace) {
@@ -182,31 +200,22 @@ async function updateMapPreview(workspace: Workspace) {
   // Cancel a previous bbox request even if this workspace uses metadata.
   loadingBbox.abort();
 
-  workspaceAreaPolygon.value?.remove();
-  workspaceAreaPolygon.value = null;
+  currentAreaBounds = null;
   mapState.value = 'loading';
 
   try {
-    const polygon = await getWorkspacePolygon(workspace);
+    const area = await getWorkspaceArea(workspace);
 
     // The user selected another workspace while this one was loading.
     if (requestId !== mapRequestId) {
       return;
     }
 
-    if (!polygon) {
+    if (!area) {
       mapState.value = 'empty';
       return;
     }
 
-    const bounds = polygon.getBounds();
-
-    if (!bounds.isValid()) {
-      mapState.value = 'error';
-      return;
-    }
-
-    workspaceAreaPolygon.value = polygon;
     mapState.value = 'ready';
 
     // Wait until v-show makes the map surface visible.
@@ -216,16 +225,20 @@ async function updateMapPreview(workspace: Workspace) {
       return;
     }
 
-    if (!map.value) {
-      initMap();
+    await ensureMap();
+
+    if (requestId !== mapRequestId) {
+      return;
     }
 
-    if (!map.value) {
+    if (!map) {
       mapState.value = 'error';
       return;
     }
 
-    polygon.addTo(map.value);
+    const source = map.getSource(AREA_SOURCE_ID) as import('maplibre-gl').GeoJSONSource | undefined;
+    source?.setData(area.geojson as any);
+    currentAreaBounds = area.bounds;
     resizeMap();
   }
   catch (error: unknown) {

--- a/components/dashboard/Map.vue
+++ b/components/dashboard/Map.vue
@@ -31,6 +31,7 @@
 import { LoadingContext } from '~/services/loading';
 import { workspacesClient } from '~/services/index';
 import { isRecord, parseMetadata } from '~/util/metadata';
+import { OPENFREEMAP_STYLE_URL } from '~/util/map-style';
 
 import type { Workspace, WorkspaceCenter } from '~/types/workspaces';
 
@@ -141,10 +142,7 @@ function initMap() {
 
   map.value = L.map(mapElement.value) as LeafletMap;
 
-  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    maxZoom: 19,
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-  }).addTo(map.value);
+  L.maplibreGL({ style: OPENFREEMAP_STYLE_URL }).addTo(map.value);
 }
 
 async function getWorkspacePolygon(

--- a/components/project-wizard/AoiGeometryMap.vue
+++ b/components/project-wizard/AoiGeometryMap.vue
@@ -43,7 +43,7 @@ import {
   getProjectWizardAoiBounds,
   getProjectWizardAoiVertices,
 } from '~/services/project-wizard-aoi';
-import { OPENFREEMAP_STYLE_URL } from '~/util/map-style';
+import { createMaplibreMap } from '~/util/map-style';
 
 interface Props {
   aoi?: ProjectWizardAreaFeature | null;
@@ -93,7 +93,6 @@ const emptyCollection: FeatureCollection = {
 
 type VertexFeature = Feature<Point, { vertexIndex: number }>;
 
-let maplibregl: typeof import('maplibre-gl') | null = null;
 let wizardMap: import('maplibre-gl').Map | null = null;
 let isDraggingVertex = false;
 let activeVertexIndex: number | null = null;
@@ -108,25 +107,18 @@ onMounted(async () => {
     return;
   }
 
-  maplibregl = await import('maplibre-gl');
+  const handle = await createMaplibreMap(mapRef.value, { center: DEFAULT_CENTER, zoom: 8 });
 
-  wizardMap = new maplibregl.Map({
-    container: mapRef.value,
-    style: OPENFREEMAP_STYLE_URL,
-    center: DEFAULT_CENTER,
-    zoom: 8,
-  });
+  wizardMap = handle.map;
 
-  wizardMap.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
+  await handle.ready;
 
-  wizardMap.on('load', () => {
-    ensureLayers();
-    bindInteractionHandlers();
-    isMapStyleLoaded.value = true;
-    syncSources();
-    syncInteractionState();
-    applyViewport();
-  });
+  ensureLayers();
+  bindInteractionHandlers();
+  isMapStyleLoaded.value = true;
+  syncSources();
+  syncInteractionState();
+  applyViewport();
 });
 
 watch(

--- a/components/project-wizard/AoiGeometryMap.vue
+++ b/components/project-wizard/AoiGeometryMap.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts">
-import type { StyleSpecification,
+import type {
   CircleLayerSpecification,
   ExpressionSpecification,
   FillLayerSpecification,
@@ -19,7 +19,8 @@ import type { StyleSpecification,
   MapLayerMouseEvent,
   MapMouseEvent,
   PaddingOptions,
-  SymbolLayerSpecification } from 'maplibre-gl';
+  SymbolLayerSpecification
+} from 'maplibre-gl';
 </script>
 
 <script setup lang="ts">
@@ -42,6 +43,7 @@ import {
   getProjectWizardAoiBounds,
   getProjectWizardAoiVertices,
 } from '~/services/project-wizard-aoi';
+import { OPENFREEMAP_STYLE_URL } from '~/util/map-style';
 
 interface Props {
   aoi?: ProjectWizardAreaFeature | null;
@@ -84,26 +86,6 @@ const VIEWPORT_ZOOM_TOLERANCE = 0.01;
 
 const mapRef = useTemplateRef<HTMLDivElement>('mapRef');
 
-const baseMapStyle: StyleSpecification = {
-  version: 8,
-  sources: {
-    osm: {
-      type: 'raster',
-      tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
-      tileSize: 256,
-      attribution: '&copy; OpenStreetMap contributors',
-      maxzoom: 19,
-    },
-  },
-  layers: [
-    {
-      id: 'osm',
-      type: 'raster',
-      source: 'osm',
-    },
-  ],
-};
-
 const emptyCollection: FeatureCollection = {
   type: 'FeatureCollection',
   features: [],
@@ -130,7 +112,7 @@ onMounted(async () => {
 
   wizardMap = new maplibregl.Map({
     container: mapRef.value,
-    style: baseMapStyle,
+    style: OPENFREEMAP_STYLE_URL,
     center: DEFAULT_CENTER,
     zoom: 8,
   });

--- a/components/review/Map.vue
+++ b/components/review/Map.vue
@@ -19,25 +19,8 @@ import type { ReviewListItem } from '~/services/review';
 import type { AdiffAction } from '~/types/adiff';
 import type { OsmChangeset, OsmNote } from '~/types/osm';
 import type { TdeiFeedback } from '~/types/tdei';
-// const reviewMapStyle = {
-//   'version': 8,
-//  'sources': {
-//     'osm': {
-//      'type': 'raster',
-//      'tiles': ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'],
-//      'tileSize': 256,
-//       'attribution': '&copy; OpenStreetMap Contributors',
-//       'maxzoom': 19
-//     }
-//   },
-//   'layers': [
-//     {
-//       'id': 'osm',
-//       'type': 'raster',
-//       'source': 'osm'
-//     }
-//   ]
-// };
+// import { OPENFREEMAP_STYLE_URL } from '~/util/map-style';
+// const reviewMapStyle = OPENFREEMAP_STYLE_URL;
 
 const reviewMapStyle: StyleSpecification = {
   version: 8,

--- a/components/workspace-project-details/ProjectMap.vue
+++ b/components/workspace-project-details/ProjectMap.vue
@@ -86,7 +86,6 @@ import type {
   MapLayerMouseEvent,
   Marker,
   PaddingOptions,
-  StyleSpecification,
 } from 'maplibre-gl';
 
 import type {
@@ -97,6 +96,7 @@ import type {
   ProjectWizardGeneratedTaskFeatureCollection,
   ProjectWizardTaskPreviewFeatureCollection,
 } from '~/types/project-wizard';
+import { OPENFREEMAP_STYLE_URL } from '~/util/map-style';
 
 interface Props {
   aoi: WorkspaceProjectAoiFeature | null;
@@ -131,26 +131,6 @@ const DEFAULT_CENTER: [number, number] = [-122.3321, 47.6062];
  * (each corner is a valid `LngLatLike`) when handed to `fitBounds`.
  */
 type BoundsTuple = [[number, number], [number, number]];
-
-const baseMapStyle: StyleSpecification = {
-  version: 8,
-  sources: {
-    osm: {
-      type: 'raster',
-      tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
-      tileSize: 256,
-      attribution: '&copy; OpenStreetMap contributors',
-      maxzoom: 19,
-    },
-  },
-  layers: [
-    {
-      id: 'osm',
-      type: 'raster',
-      source: 'osm',
-    },
-  ],
-};
 
 const emptyCollection: FeatureCollection = {
   type: 'FeatureCollection',
@@ -245,7 +225,7 @@ onMounted(async () => {
 
   detailMap = new maplibregl.Map({
     container: mapRef.value,
-    style: baseMapStyle,
+    style: OPENFREEMAP_STYLE_URL,
     center: DEFAULT_CENTER,
     zoom: 9,
   });

--- a/components/workspace-project-details/ProjectMap.vue
+++ b/components/workspace-project-details/ProjectMap.vue
@@ -96,7 +96,7 @@ import type {
   ProjectWizardGeneratedTaskFeatureCollection,
   ProjectWizardTaskPreviewFeatureCollection,
 } from '~/types/project-wizard';
-import { OPENFREEMAP_STYLE_URL } from '~/util/map-style';
+import { createMaplibreMap } from '~/util/map-style';
 
 interface Props {
   aoi: WorkspaceProjectAoiFeature | null;
@@ -221,30 +221,10 @@ onMounted(async () => {
     return;
   }
 
-  maplibregl = await import('maplibre-gl');
+  const handle = await createMaplibreMap(mapRef.value, { center: DEFAULT_CENTER, zoom: 9, controlPosition: 'bottom-right' });
 
-  detailMap = new maplibregl.Map({
-    container: mapRef.value,
-    style: OPENFREEMAP_STYLE_URL,
-    center: DEFAULT_CENTER,
-    zoom: 9,
-  });
-
-  detailMap.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'bottom-right');
-
-  detailMap.on('load', () => {
-    detailMap?.resize();
-    ensureLayers();
-    bindInteractionHandlers();
-    syncSources();
-    fitMapToData();
-    mapReady.value = true;
-    setTimeout(() => {
-      if (!detailMap) return;
-      syncSources();
-      fitMapToData();
-    }, 300);
-  });
+  maplibregl = handle.maplibregl;
+  detailMap = handle.map;
 
   mapResizeObserver = new ResizeObserver(() => {
     if (!detailMap) return;
@@ -255,6 +235,20 @@ onMounted(async () => {
     }
   });
   mapResizeObserver.observe(mapRef.value);
+
+  await handle.ready;
+
+  detailMap.resize();
+  ensureLayers();
+  bindInteractionHandlers();
+  syncSources();
+  fitMapToData();
+  mapReady.value = true;
+  setTimeout(() => {
+    if (!detailMap) return;
+    syncSources();
+    fitMapToData();
+  }, 300);
 });
 
 /**

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,9 +32,15 @@ export default defineNuxtConfig({
       link: [
         { rel: 'stylesheet', href: 'https://material-icons.github.io/material-icons-font/css/outline.css' },
         { rel: 'stylesheet', href: 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css' },
+        { rel: 'stylesheet', href: 'https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.css' },
       ],
       script: [
         { src: 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js' },
+        // Leaflet's OSM tile layers are being replaced with OpenFreeMap's vector
+        // style; the Leaflet maps render it via this MapLibre GL + binding pair
+        // (loaded as globals like Leaflet itself, rather than bundled via npm).
+        { src: 'https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.js' },
+        { src: 'https://unpkg.com/@maplibre/maplibre-gl-leaflet@0.1.4/leaflet-maplibre-gl.js' },
       ],
     },
     pageTransition: { name: 'page', mode: 'out-in' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -31,16 +31,6 @@ export default defineNuxtConfig({
       ],
       link: [
         { rel: 'stylesheet', href: 'https://material-icons.github.io/material-icons-font/css/outline.css' },
-        { rel: 'stylesheet', href: 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css' },
-        { rel: 'stylesheet', href: 'https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.css' },
-      ],
-      script: [
-        { src: 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js' },
-        // Leaflet's OSM tile layers are being replaced with OpenFreeMap's vector
-        // style; the Leaflet maps render it via this MapLibre GL + binding pair
-        // (loaded as globals like Leaflet itself, rather than bundled via npm).
-        { src: 'https://unpkg.com/maplibre-gl@5.10.0/dist/maplibre-gl.js' },
-        { src: 'https://unpkg.com/@maplibre/maplibre-gl-leaflet@0.1.4/leaflet-maplibre-gl.js' },
       ],
     },
     pageTransition: { name: 'page', mode: 'out-in' },

--- a/pages/workspace/create/tdei.vue
+++ b/pages/workspace/create/tdei.vue
@@ -187,6 +187,7 @@ import { tdeiClient, workspacesClient } from '~/services/index';
 import type { TdeiDatasetSummary } from '~/types/tdei';
 import { BModal } from 'bootstrap-vue-next/components/BModal';
 import type { ComponentExposed } from 'vue-component-type-helpers';
+import { OPENFREEMAP_STYLE_URL } from '~/util/map-style';
 
 declare const L: any;
 
@@ -281,13 +282,9 @@ function initMap() {
     map.value.remove()
   }
 
-  // TODO: use Mapbox
   map.value = L.map('dataset_map');
 
-  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    maxZoom: 19,
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-  }).addTo(map.value);
+  L.maplibreGL({ style: OPENFREEMAP_STYLE_URL }).addTo(map.value);
 
   if (record.metadata?.dataset_detail?.dataset_area) {
     const area = L.geoJSON(record.metadata.dataset_detail.dataset_area).addTo(map.value)

--- a/pages/workspace/create/tdei.vue
+++ b/pages/workspace/create/tdei.vue
@@ -187,9 +187,11 @@ import { tdeiClient, workspacesClient } from '~/services/index';
 import type { TdeiDatasetSummary } from '~/types/tdei';
 import { BModal } from 'bootstrap-vue-next/components/BModal';
 import type { ComponentExposed } from 'vue-component-type-helpers';
-import { OPENFREEMAP_STYLE_URL } from '~/util/map-style';
+import { createMaplibreMap } from '~/util/map-style';
+import { getGeoJsonBounds } from '~/util/geojson';
 
-declare const L: any;
+const DATASET_AREA_SOURCE_ID = 'dataset-area';
+const DATASET_AREA_COLOR = '#3388ff';
 
 const context = reactive(new TdeiImporterContext());
 const importer = new TdeiImporter(workspacesClient, context);
@@ -198,7 +200,8 @@ const loading = reactive(new LoadingContext());
 const route = useRoute();
 const tdeiRecordId = ref<string | null>(null);
 const record = reactive<Record<string, any>>({});
-const map = ref<any>({});
+let map: import('maplibre-gl').Map | null = null;
+let mapInitId = 0;
 const workspaceTitle = ref('');
 const projectGroupId = ref<string | null>(null);
 const datasetError = ref<string | null>(null);
@@ -270,29 +273,61 @@ async function getDatasetInfo(id: string | null) {
   workspaceTitle.value = record.metadata?.dataset_detail?.name ?? ''
   tdeiRecordId.value = record.tdei_dataset_id
 
-  initMap();
+  void initMap();
 }
 
 onMounted(async () => {
   tdeiRecordId.value = route.query.tdeiRecordId?.toString() || null;
 })
 
-function initMap() {
-  if (map.value && map.value.remove) {
-    map.value.remove()
+async function initMap() {
+  const initId = ++mapInitId
+
+  if (map) {
+    map.remove()
+    map = null
   }
 
-  map.value = L.map('dataset_map');
+  const handle = await createMaplibreMap('dataset_map', { center: [0, 0], zoom: 0 })
 
-  L.maplibreGL({ style: OPENFREEMAP_STYLE_URL }).addTo(map.value);
+  // A newer dataset selection already handled map creation while this one
+  // was still loading the module.
+  if (initId !== mapInitId) {
+    handle.map.remove()
+    return
+  }
 
-  if (record.metadata?.dataset_detail?.dataset_area) {
-    const area = L.geoJSON(record.metadata.dataset_detail.dataset_area).addTo(map.value)
-    const bounds = area.getBounds()
+  map = handle.map
 
-    if (bounds.isValid()) {
-      map.value.fitBounds(bounds)
-    }
+  const datasetArea = record.metadata?.dataset_detail?.dataset_area
+  const bounds = datasetArea ? getGeoJsonBounds(datasetArea) : null
+
+  await handle.ready
+
+  if (initId !== mapInitId) {
+    handle.map.remove()
+    return
+  }
+
+  handle.map.addSource(DATASET_AREA_SOURCE_ID, {
+    type: 'geojson',
+    data: datasetArea ?? { type: 'FeatureCollection', features: [] },
+  })
+  handle.map.addLayer({
+    id: `${DATASET_AREA_SOURCE_ID}-fill`,
+    type: 'fill',
+    source: DATASET_AREA_SOURCE_ID,
+    paint: { 'fill-color': DATASET_AREA_COLOR, 'fill-opacity': 0.2 },
+  })
+  handle.map.addLayer({
+    id: `${DATASET_AREA_SOURCE_ID}-line`,
+    type: 'line',
+    source: DATASET_AREA_SOURCE_ID,
+    paint: { 'line-color': DATASET_AREA_COLOR, 'line-width': 3 },
+  })
+
+  if (bounds) {
+    handle.map.fitBounds(bounds)
   }
 }
 

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,11 +1,8 @@
-// Ambient declarations for editor/map libraries injected as runtime globals
+// Ambient declarations for editor libraries injected as runtime globals
 // (loaded via <script> at runtime rather than imported), so they have no types.
 export {};
 
 declare global {
-  // Leaflet, loaded as a global `L` (no @types/leaflet installed).
-  const L: any;
-
   interface Window {
     // The iD / Pathways editor namespace, attached by the iD script on load.
     iD: any;

--- a/util/geojson.ts
+++ b/util/geojson.ts
@@ -49,6 +49,59 @@ export function polygonToBbox(polygonGeometry: any): [number, number, number, nu
   return [minLat, minLon, maxLat, maxLon]
 }
 
+function walkGeoJson(node: any, visitGeometry: (geometry: any) => void): void {
+  if (!node || typeof node !== 'object') return
+
+  switch (node.type) {
+    case 'FeatureCollection':
+      for (const feature of node.features ?? []) walkGeoJson(feature, visitGeometry)
+      return
+    case 'Feature':
+      walkGeoJson(node.geometry, visitGeometry)
+      return
+    case 'GeometryCollection':
+      for (const geometry of node.geometries ?? []) walkGeoJson(geometry, visitGeometry)
+      return
+    default:
+      if (Array.isArray(node.coordinates)) visitGeometry(node)
+  }
+}
+
+function extendBounds(bounds: [number, number, number, number], coordinates: any): void {
+  if (
+    Array.isArray(coordinates)
+    && coordinates.length >= 2
+    && typeof coordinates[0] === 'number'
+    && typeof coordinates[1] === 'number'
+  ) {
+    const [lon, lat] = coordinates
+    bounds[0] = Math.min(bounds[0], lon)
+    bounds[1] = Math.min(bounds[1], lat)
+    bounds[2] = Math.max(bounds[2], lon)
+    bounds[3] = Math.max(bounds[3], lat)
+    return
+  }
+
+  if (Array.isArray(coordinates)) {
+    for (const item of coordinates) extendBounds(bounds, item)
+  }
+}
+
+// Computes a [[minLng, minLat], [maxLng, maxLat]] bounding box for any GeoJSON
+// shape (Feature, FeatureCollection, GeometryCollection, or a bare geometry of
+// any type). Returns null if no coordinates are found.
+export function getGeoJsonBounds(geojson: any): [[number, number], [number, number]] | null {
+  const bounds: [number, number, number, number] = [Infinity, Infinity, -Infinity, -Infinity]
+
+  walkGeoJson(geojson, geometry => extendBounds(bounds, geometry.coordinates))
+
+  if (!Number.isFinite(bounds[0])) {
+    return null
+  }
+
+  return [[bounds[0], bounds[1]], [bounds[2], bounds[3]]]
+}
+
 export function shapeToCenter(shape: any) {
   if (shape.type === 'Polygon') {
     const bbox = polygonToBbox(shape)

--- a/util/map-style.ts
+++ b/util/map-style.ts
@@ -3,3 +3,42 @@
 // tile service built from OSM data instead; MapLibre GL fetches its full
 // style (sources, layers, attribution) from this single URL.
 export const OPENFREEMAP_STYLE_URL = 'https://tiles.openfreemap.org/styles/positron';
+
+export interface MaplibreMapHandle {
+  maplibregl: typeof import('maplibre-gl');
+  map: import('maplibre-gl').Map;
+  /** Resolves once the style has loaded and the map is ready for sources/layers. */
+  ready: Promise<void>;
+}
+
+/**
+ * Dynamically imports maplibre-gl and constructs a Map on the OpenFreeMap
+ * style, with the NavigationControl every map component in this app uses.
+ * Deferring the import keeps maplibre-gl's bundle out of a page's critical
+ * path until a map component actually mounts.
+ */
+export async function createMaplibreMap(
+  container: string | HTMLElement,
+  options: {
+    center: [number, number];
+    zoom: number;
+    controlPosition?: import('maplibre-gl').ControlPosition;
+  }
+): Promise<MaplibreMapHandle> {
+  const maplibregl = await import('maplibre-gl');
+
+  const map = new maplibregl.Map({
+    container,
+    style: OPENFREEMAP_STYLE_URL,
+    center: options.center,
+    zoom: options.zoom,
+  });
+
+  map.addControl(new maplibregl.NavigationControl({ showCompass: false }), options.controlPosition ?? 'top-right');
+
+  const ready = new Promise<void>((resolve) => {
+    map.on('load', () => resolve());
+  });
+
+  return { maplibregl, map, ready };
+}

--- a/util/map-style.ts
+++ b/util/map-style.ts
@@ -1,0 +1,5 @@
+// OpenStreetMap's own tile server now requires a Referrer header and isn't
+// intended for production third-party use. OpenFreeMap hosts a free vector
+// tile service built from OSM data instead; MapLibre GL fetches its full
+// style (sources, layers, attribution) from this single URL.
+export const OPENFREEMAP_STYLE_URL = 'https://tiles.openfreemap.org/styles/positron';


### PR DESCRIPTION
This switches the background layers for a few map widgets from OSM to OFM tiles to resolve OSM's new referrer requirement on tile requests. OFM is a stand-in&mdash;we'll pick a long-term tile provider separately.

As part of these changes, we also reduce our map library count by dropping the bolted-on Leaflet library in favor of the more proper installation of MapLibre GL that already exists for the review queue and TM.

Resolves #4097.

<img width="1071" height="783" alt="image" src="https://github.com/user-attachments/assets/bd4dfae8-58f1-4129-b5e9-0c2349db7be7" />
